### PR TITLE
Add seeding for Country model

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+
+	"ptop/config"
+	"ptop/internal/db"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("config load failed: %v", err)
+	}
+
+	gormDB, err := db.NewDB(cfg.DSN)
+	if err != nil {
+		log.Fatalf("db connect failed: %v", err)
+	}
+
+	if err := db.SeedCountries(gormDB); err != nil {
+		log.Fatalf("seed countries failed: %v", err)
+	}
+
+	log.Println("countries seeded")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module ptop
 go 1.24.1
 
 require (
+	github.com/biter777/countries v1.7.5
 	github.com/gin-gonic/gin v1.10.1
 	github.com/joho/godotenv v1.5.1
 	github.com/matoous/go-nanoid/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/biter777/countries v1.7.5 h1:MJ+n3+rSxWQdqVJU8eBy9RqcdH6ePPn4PJHocVWUa+Q=
+github.com/biter777/countries v1.7.5/go.mod h1:1HSpZ526mYqKJcpT5Ti1kcGQ0L0SrXWIaptUWjFfv2E=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=

--- a/internal/db/seed.go
+++ b/internal/db/seed.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"github.com/biter777/countries"
+	"gorm.io/gorm"
+	"ptop/internal/models"
+)
+
+// SeedCountries заполняет таблицу стран перечнем всех стран на английском языке.
+func SeedCountries(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.Country{}).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	var list []models.Country
+	for _, code := range countries.All() {
+		list = append(list, models.Country{Name: code.String()})
+	}
+	return db.Create(&list).Error
+}

--- a/internal/db/seed_test.go
+++ b/internal/db/seed_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/biter777/countries"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+func TestSeedCountries(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := gdb.AutoMigrate(&models.Country{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := SeedCountries(gdb); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var count int64
+	if err := gdb.Model(&models.Country{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if int(count) != countries.Total() {
+		t.Fatalf("expected %d countries, got %d", countries.Total(), count)
+	}
+	if err := SeedCountries(gdb); err != nil {
+		t.Fatalf("reseeding: %v", err)
+	}
+	var count2 int64
+	gdb.Model(&models.Country{}).Count(&count2)
+	if count2 != count {
+		t.Fatalf("expected no duplicates after reseed; got %d vs %d", count2, count)
+	}
+}


### PR DESCRIPTION
## Summary
- seed database with full list of countries
- add command to run country seeding
- cover seeding with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e32cfef788332bcb406ab39099c54