### PR TITLE
Добавлены тесты для Health и посев тестовых данных

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -21,6 +21,12 @@ func main() {
 	if err := db.SeedCountries(gormDB); err != nil {
 		log.Fatalf("seed countries failed: %v", err)
 	}
+	if err := db.SeedPaymentMethods(gormDB); err != nil {
+		log.Fatalf("seed payment methods failed: %v", err)
+	}
+	if err := db.SeedAssets(gormDB); err != nil {
+		log.Fatalf("seed assets failed: %v", err)
+	}
 
-	log.Println("countries seeded")
+	log.Println("seed completed")
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -972,6 +972,9 @@ const docTemplate = `{
                 "amount": {
                     "type": "string"
                 },
+                "price": {
+                    "type": "string"
+                },
                 "client_payment_method_ids": {
                     "type": "array",
                     "items": {
@@ -1150,6 +1153,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "price": {
                     "type": "number"
                 },
                 "clientID": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -965,6 +965,9 @@
                 "amount": {
                     "type": "string"
                 },
+                "price": {
+                    "type": "string"
+                },
                 "client_payment_method_ids": {
                     "type": "array",
                     "items": {
@@ -1143,6 +1146,9 @@
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "price": {
                     "type": "number"
                 },
                 "clientID": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -66,6 +66,8 @@ definitions:
     properties:
       amount:
         type: string
+      price:
+        type: string
       client_payment_method_ids:
         items:
           type: string
@@ -181,6 +183,8 @@ definitions:
   models.Offer:
     properties:
       amount:
+        type: number
+      price:
         type: number
       clientID:
         type: string

--- a/internal/db/seed.go
+++ b/internal/db/seed.go
@@ -3,6 +3,7 @@ package db
 import (
 	"github.com/biter777/countries"
 	"gorm.io/gorm"
+
 	"ptop/internal/models"
 )
 
@@ -21,4 +22,36 @@ func SeedCountries(db *gorm.DB) error {
 		list = append(list, models.Country{Name: code.String()})
 	}
 	return db.Create(&list).Error
+}
+
+// SeedPaymentMethods добавляет базовые платёжные методы, если таблица пуста.
+func SeedPaymentMethods(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.PaymentMethod{}).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	methods := []models.PaymentMethod{
+		{Name: "Bank"},
+		{Name: "Cash"},
+	}
+	return db.Create(&methods).Error
+}
+
+// SeedAssets добавляет базовые активы, если таблица пуста.
+func SeedAssets(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.Asset{}).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	assets := []models.Asset{
+		{Name: "USD", Type: "fiat", IsConvertible: true},
+		{Name: "BTC", Type: "crypto"},
+	}
+	return db.Create(&assets).Error
 }

--- a/internal/db/seed_test.go
+++ b/internal/db/seed_test.go
@@ -37,3 +37,37 @@ func TestSeedCountries(t *testing.T) {
 		t.Fatalf("expected no duplicates after reseed; got %d vs %d", count2, count)
 	}
 }
+
+func TestSeedPaymentMethodsAndAssets(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := gdb.AutoMigrate(&models.PaymentMethod{}, &models.Asset{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := SeedPaymentMethods(gdb); err != nil {
+		t.Fatalf("seed payment methods: %v", err)
+	}
+	if err := SeedAssets(gdb); err != nil {
+		t.Fatalf("seed assets: %v", err)
+	}
+	var pmCount, assetCount int64
+	gdb.Model(&models.PaymentMethod{}).Count(&pmCount)
+	gdb.Model(&models.Asset{}).Count(&assetCount)
+	if pmCount != 2 || assetCount != 2 {
+		t.Fatalf("expected 2 methods and 2 assets, got %d and %d", pmCount, assetCount)
+	}
+	if err := SeedPaymentMethods(gdb); err != nil {
+		t.Fatalf("reseeding methods: %v", err)
+	}
+	if err := SeedAssets(gdb); err != nil {
+		t.Fatalf("reseeding assets: %v", err)
+	}
+	var pmCount2, assetCount2 int64
+	gdb.Model(&models.PaymentMethod{}).Count(&pmCount2)
+	gdb.Model(&models.Asset{}).Count(&assetCount2)
+	if pmCount2 != pmCount || assetCount2 != assetCount {
+		t.Fatalf("expected no duplicates after reseed")
+	}
+}

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -1,30 +1,30 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/http"
 )
 
+// Health godoc
+// @Summary Проверка состояния сервиса
+// @Tags health
+// @Produce json
+// @Success 200 {object} StatusResponse
+// @Failure 503 {object} ErrorResponse
+// @Router /health [get]
 func Health(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// получаем *sql.DB из GORM
 		sqlDB, err := db.DB()
 		if err != nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"status": "db error",
-				"error":  err.Error(),
-			})
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "db error"})
 			return
 		}
-
 		if err := sqlDB.Ping(); err != nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"status": "db down",
-				"error":  err.Error(),
-			})
+			c.JSON(http.StatusServiceUnavailable, ErrorResponse{Error: "db down"})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		c.JSON(http.StatusOK, StatusResponse{Status: "ok"})
 	}
 }

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestHealthOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	r := gin.Default()
+	r.GET("/health", Health(db))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/health", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestHealthDBDown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.Close()
+	r := gin.Default()
+	r.GET("/health", Health(db))
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/health", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", w.Code)
+	}
+}

--- a/internal/handlers/offer.go
+++ b/internal/handlers/offer.go
@@ -15,6 +15,7 @@ type OfferRequest struct {
 	MaxAmount              string   `json:"max_amount"`
 	MinAmount              string   `json:"min_amount"`
 	Amount                 string   `json:"amount"`
+	Price                  string   `json:"price"`
 	FromAssetID            string   `json:"from_asset_id"`
 	ToAssetID              string   `json:"to_asset_id"`
 	Conditions             string   `json:"conditions"`
@@ -61,6 +62,11 @@ func CreateOffer(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid amount"})
 			return
 		}
+		price, err := decimal.NewFromString(r.Price)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid price"})
+			return
+		}
 		timeout := r.OrderExpirationTimeout
 		if timeout < 15 {
 			timeout = 15
@@ -103,6 +109,7 @@ func CreateOffer(db *gorm.DB) gin.HandlerFunc {
 			MaxAmount:              maxAmount,
 			MinAmount:              minAmount,
 			Amount:                 amount,
+			Price:                  price,
 			FromAssetID:            r.FromAssetID,
 			ToAssetID:              r.ToAssetID,
 			Conditions:             r.Conditions,
@@ -176,6 +183,11 @@ func UpdateOffer(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid amount"})
 			return
 		}
+		price, err := decimal.NewFromString(r.Price)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid price"})
+			return
+		}
 		timeout := r.OrderExpirationTimeout
 		if timeout < 15 {
 			timeout = 15
@@ -214,6 +226,7 @@ func UpdateOffer(db *gorm.DB) gin.HandlerFunc {
 		offer.MaxAmount = maxAmount
 		offer.MinAmount = minAmount
 		offer.Amount = amount
+		offer.Price = price
 		offer.FromAssetID = r.FromAssetID
 		offer.ToAssetID = r.ToAssetID
 		offer.Conditions = r.Conditions

--- a/internal/handlers/offer_test.go
+++ b/internal/handlers/offer_test.go
@@ -71,6 +71,7 @@ func TestOfferLifecycle(t *testing.T) {
 		MaxAmount:              "100",
 		MinAmount:              "10",
 		Amount:                 "50",
+		Price:                  "0.12345678",
 		FromAssetID:            asset1.ID,
 		ToAssetID:              asset2.ID,
 		OrderExpirationTimeout: 20,
@@ -89,6 +90,9 @@ func TestOfferLifecycle(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &offer1)
 	if offer1.IsEnabled {
 		t.Fatalf("offer should be disabled by default")
+	}
+	if offer1.Price.String() != "0.12345678" {
+		t.Fatalf("price not set")
 	}
 
 	// enable first offer
@@ -172,6 +176,7 @@ func TestOfferLifecycle(t *testing.T) {
 
 	// update second offer
 	reqBody.Conditions = "updated"
+	reqBody.Price = "0.87654321"
 	b, _ = json.Marshal(reqBody)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("PUT", "/client/offers/"+offer2.ID, bytes.NewReader(b))
@@ -184,6 +189,9 @@ func TestOfferLifecycle(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &offer2)
 	if offer2.Conditions != "updated" {
 		t.Fatalf("offer not updated")
+	}
+	if offer2.Price.String() != "0.87654321" {
+		t.Fatalf("price not updated")
 	}
 
 	// disable second offer

--- a/internal/models/offer.go
+++ b/internal/models/offer.go
@@ -13,6 +13,7 @@ type Offer struct {
 	MaxAmount              decimal.Decimal `gorm:"type:decimal(32,8);not null"`
 	MinAmount              decimal.Decimal `gorm:"type:decimal(32,8);not null"`
 	Amount                 decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	Price                  decimal.Decimal `gorm:"type:decimal(32,8);not null"`
 	FromAssetID            string          `gorm:"size:21;not null"`
 	FromAsset              Asset           `gorm:"foreignKey:FromAssetID" json:"-"`
 	ToAssetID              string          `gorm:"size:21;not null"`


### PR DESCRIPTION
## Summary
- улучшен обработчик `/health` и добавлена документация Swagger
- добавлены тесты для обработчика `/health`
- расширен механизм посева: теперь создаются активы и платёжные методы
- добавлено поле `price` в модель `Offer`, обновлены хендлеры, тесты и swagger

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e3995dea88332a0c0435a8e2afdc9