### PR TITLE
Добавлены модели и хендлеры ордеров и баланса

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -449,6 +449,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/client/balances": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "balances"
+                ],
+                "summary": "Список балансов клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Balance"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/escrows": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "escrows"
+                ],
+                "summary": "Список эскроу клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Escrow"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/client/offers": {
             "get": {
                 "security": [
@@ -654,6 +708,75 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/client/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Список ордеров клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Order"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Создать ордер",
+                "parameters": [
+                    {
+                        "description": "данные",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.OrderRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -1095,6 +1218,20 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.OrderRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "offer_id": {
+                    "type": "string"
+                },
+                "payment_method_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -1214,6 +1351,32 @@ const docTemplate = `{
                 }
             }
         },
+        "models.Balance": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
@@ -1247,6 +1410,35 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Escrow": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "offerID": {
+                    "type": "string"
+                },
+                "orderID": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }
@@ -1297,6 +1489,56 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "ttl": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Order": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "buyerID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "fromAssetID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isEscrow": {
+                    "type": "boolean"
+                },
+                "offerID": {
+                    "type": "string"
+                },
+                "paymentMethodID": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "releasedAt": {
+                    "type": "string"
+                },
+                "sellerID": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "toAssetID": {
                     "type": "string"
                 },
                 "updatedAt": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -442,6 +442,60 @@
                 }
             }
         },
+        "/client/balances": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "balances"
+                ],
+                "summary": "Список балансов клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Balance"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/escrows": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "escrows"
+                ],
+                "summary": "Список эскроу клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Escrow"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/client/offers": {
             "get": {
                 "security": [
@@ -647,6 +701,75 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/client/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Список ордеров клиента",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Order"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Создать ордер",
+                "parameters": [
+                    {
+                        "description": "данные",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.OrderRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
@@ -1088,6 +1211,20 @@
                 }
             }
         },
+        "handlers.OrderRequest": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "offer_id": {
+                    "type": "string"
+                },
+                "payment_method_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ProfileResponse": {
             "type": "object",
             "properties": {
@@ -1207,6 +1344,32 @@
                 }
             }
         },
+        "models.Balance": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
@@ -1240,6 +1403,35 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Escrow": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "offerID": {
+                    "type": "string"
+                },
+                "orderID": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }
@@ -1290,6 +1482,56 @@
                     "type": "string"
                 },
                 "ttl": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Order": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "buyerID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "fromAssetID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isEscrow": {
+                    "type": "boolean"
+                },
+                "offerID": {
+                    "type": "string"
+                },
+                "paymentMethodID": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "releasedAt": {
+                    "type": "string"
+                },
+                "sellerID": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "toAssetID": {
                     "type": "string"
                 },
                 "updatedAt": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -85,6 +85,15 @@ definitions:
       to_asset_id:
         type: string
     type: object
+  handlers.OrderRequest:
+    properties:
+      amount:
+        type: string
+      offer_id:
+        type: string
+      payment_method_id:
+        type: string
+    type: object
   handlers.ProfileResponse:
     properties:
       pincode_set:
@@ -161,6 +170,23 @@ definitions:
       type:
         type: string
     type: object
+  models.Balance:
+    properties:
+      amount:
+        type: number
+      amountEscrow:
+        type: number
+      assetID:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      id:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   models.ClientPaymentMethod:
     properties:
       city:
@@ -183,6 +209,25 @@ definitions:
       id:
         type: string
       name:
+        type: string
+    type: object
+  models.Escrow:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      id:
+        type: string
+      offerID:
+        type: string
+      orderID:
+        type: string
+      updatedAt:
         type: string
     type: object
   models.Offer:
@@ -216,6 +261,39 @@ definitions:
       toAssetID:
         type: string
       ttl:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  models.Order:
+    properties:
+      amount:
+        type: number
+      buyerID:
+        type: string
+      createdAt:
+        type: string
+      expiresAt:
+        type: string
+      fromAssetID:
+        type: string
+      id:
+        type: string
+      isEscrow:
+        type: boolean
+      offerID:
+        type: string
+      paymentMethodID:
+        type: string
+      price:
+        type: number
+      releasedAt:
+        type: string
+      sellerID:
+        type: string
+      status:
+        type: string
+      toAssetID:
         type: string
       updatedAt:
         type: string
@@ -527,6 +605,38 @@ paths:
       summary: Смена имени пользователя
       tags:
       - auth
+  /client/balances:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Balance'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список балансов клиента
+      tags:
+      - balances
+  /client/escrows:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Escrow'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список эскроу клиента
+      tags:
+      - escrows
   /client/offers:
     get:
       parameters:
@@ -658,6 +768,48 @@ paths:
       summary: Включить объявление
       tags:
       - offers
+  /client/orders:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Order'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список ордеров клиента
+      tags:
+      - orders
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: данные
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.OrderRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Order'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Создать ордер
+      tags:
+      - orders
   /client/payment-methods:
     get:
       produces:

--- a/internal/handlers/balance.go
+++ b/internal/handlers/balance.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// ListClientBalances godoc
+// @Summary Список балансов клиента
+// @Tags balances
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} models.Balance
+// @Router /client/balances [get]
+func ListClientBalances(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var balances []models.Balance
+		if err := db.Where("client_id = ?", clientID).Find(&balances).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, balances)
+	}
+}

--- a/internal/handlers/balance_test.go
+++ b/internal/handlers/balance_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"ptop/internal/models"
+)
+
+func TestBalanceHandler(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	body := `{"username":"baluser","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"baluser","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status %d", w.Code)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok)
+
+	asset := models.Asset{Name: "BTC_balance", Type: "crypto"}
+	if err := db.Create(&asset).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"asset_id":"` + asset.ID + `"}`
+	req, _ = http.NewRequest("POST", "/client/wallets", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("wallet status %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/balances", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("balances status %d", w.Code)
+	}
+	var list []models.Balance
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 balance, got %d", len(list))
+	}
+	if !list[0].Amount.IsZero() {
+		t.Fatalf("amount not zero")
+	}
+}

--- a/internal/handlers/escrow.go
+++ b/internal/handlers/escrow.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// ListClientEscrows godoc
+// @Summary Список эскроу клиента
+// @Tags escrows
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} models.Escrow
+// @Router /client/escrows [get]
+func ListClientEscrows(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var escrows []models.Escrow
+		if err := db.Where("client_id = ?", clientID).Find(&escrows).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, escrows)
+	}
+}

--- a/internal/handlers/escrow_test.go
+++ b/internal/handlers/escrow_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"ptop/internal/models"
+)
+
+func TestEscrowHandler(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	body := `{"username":"escuser","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"escuser","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status %d", w.Code)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok)
+
+	var client models.Client
+	db.Where("username = ?", "escuser").First(&client)
+
+	asset := models.Asset{Name: "BTC_escrow", Type: "crypto"}
+	if err := db.Create(&asset).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	esc := models.Escrow{ClientID: client.ID, AssetID: asset.ID, Amount: decimal.RequireFromString("1")}
+	if err := db.Create(&esc).Error; err != nil {
+		t.Fatalf("escrow: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/escrows", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("escrows status %d", w.Code)
+	}
+	var list []models.Escrow
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 escrow, got %d", len(list))
+	}
+	if list[0].Amount.Cmp(decimal.RequireFromString("1")) != 0 {
+		t.Fatalf("amount mismatch")
+	}
+}

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+type OrderRequest struct {
+	OfferID         string `json:"offer_id"`
+	Amount          string `json:"amount"`
+	PaymentMethodID string `json:"payment_method_id"`
+}
+
+// CreateOrder godoc
+// @Summary Создать ордер
+// @Tags orders
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param input body OrderRequest true "данные"
+// @Success 200 {object} models.Order
+// @Failure 400 {object} ErrorResponse
+// @Router /client/orders [post]
+func CreateOrder(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var r OrderRequest
+		if err := c.BindJSON(&r); err != nil || r.OfferID == "" || r.Amount == "" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid json"})
+			return
+		}
+		amt, err := decimal.NewFromString(r.Amount)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid amount"})
+			return
+		}
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var offer models.Offer
+		if err := db.Preload("FromAsset").Preload("ToAsset").Where("id = ?", r.OfferID).First(&offer).Error; err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid offer"})
+			return
+		}
+		order := models.Order{
+			OfferID:         offer.ID,
+			BuyerID:         clientID,
+			SellerID:        offer.ClientID,
+			FromAssetID:     offer.FromAssetID,
+			ToAssetID:       offer.ToAssetID,
+			Amount:          amt,
+			Price:           offer.Price,
+			PaymentMethodID: r.PaymentMethodID,
+			Status:          "WAIT_PAYMENT",
+			ExpiresAt:       time.Now().Add(time.Duration(offer.OrderExpirationTimeout) * time.Minute),
+		}
+		if offer.FromAsset.Type == "crypto" || offer.ToAsset.Type == "crypto" {
+			order.IsEscrow = true
+		}
+		if err := db.Create(&order).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, order)
+	}
+}
+
+// ListClientOrders godoc
+// @Summary Список ордеров клиента
+// @Tags orders
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} models.Order
+// @Router /client/orders [get]
+func ListClientOrders(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var orders []models.Order
+		if err := db.Where("buyer_id = ?", clientID).Find(&orders).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, orders)
+	}
+}

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"ptop/internal/models"
+)
+
+func TestOrderHandler(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	body := `{"username":"orduser","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"orduser","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status %d", w.Code)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok)
+
+	var client models.Client
+	db.Where("username = ?", "orduser").First(&client)
+
+	asset1 := models.Asset{Name: "USD_order", Type: "fiat"}
+	asset2 := models.Asset{Name: "BTC_order", Type: "crypto"}
+	if err := db.Create(&asset1).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	if err := db.Create(&asset2).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	offer := models.Offer{
+		MaxAmount:              decimal.RequireFromString("100"),
+		MinAmount:              decimal.RequireFromString("1"),
+		Amount:                 decimal.RequireFromString("50"),
+		Price:                  decimal.RequireFromString("0.1"),
+		FromAssetID:            asset1.ID,
+		ToAssetID:              asset2.ID,
+		OrderExpirationTimeout: 10,
+		TTL:                    time.Now().Add(24 * time.Hour),
+		ClientID:               client.ID,
+	}
+	if err := db.Create(&offer).Error; err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("order status %d", w.Code)
+	}
+	var ord models.Order
+	json.Unmarshal(w.Body.Bytes(), &ord)
+	if !ord.IsEscrow {
+		t.Fatalf("expected escrow true")
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/orders", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status %d", w.Code)
+	}
+	var list []models.Order
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 order, got %d", len(list))
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +17,8 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("db open: %v", err)
 	}
@@ -29,6 +31,12 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 		&models.Asset{},
 		&models.Offer{},
 		&models.Wallet{},
+		&models.Balance{},
+		&models.Escrow{},
+		&models.Order{},
+		&models.TransactionIn{},
+		&models.TransactionOut{},
+		&models.TransactionInternal{},
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -59,6 +67,10 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	api.DELETE("/client/payment-methods/:id", DeleteClientPaymentMethod(db))
 	api.GET("/client/wallets", ListClientWallets(db))
 	api.POST("/client/wallets", CreateWallet(db))
+	api.GET("/client/balances", ListClientBalances(db))
+	api.GET("/client/escrows", ListClientEscrows(db))
+	api.GET("/client/orders", ListClientOrders(db))
+	api.POST("/client/orders", CreateOrder(db))
 
 	maxOffers := 1
 	api.GET("/offers", ListOffers(db))

--- a/internal/handlers/wallet.go
+++ b/internal/handlers/wallet.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 
 	"ptop/internal/models"
@@ -63,6 +64,11 @@ func CreateWallet(db *gorm.DB) gin.HandlerFunc {
 			EnabledAt: now,
 		}
 		if err := db.Create(&w).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		b := models.Balance{ClientID: clientID, AssetID: r.AssetID, Amount: decimal.Zero, AmountEscrow: decimal.Zero}
+		if err := db.Create(&b).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}

--- a/internal/models/balance.go
+++ b/internal/models/balance.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type Balance struct {
+	ID           string          `gorm:"primaryKey;size:21"`
+	ClientID     string          `gorm:"size:21;not null"`
+	Client       Client          `gorm:"foreignKey:ClientID" json:"-"`
+	AssetID      string          `gorm:"size:21;not null"`
+	Asset        Asset           `gorm:"foreignKey:AssetID" json:"-"`
+	Amount       decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	AmountEscrow decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	CreatedAt    time.Time       `gorm:"autoCreateTime"`
+	UpdatedAt    time.Time       `gorm:"autoUpdateTime"`
+}
+
+func (b *Balance) BeforeCreate(tx *gorm.DB) (err error) {
+	if b.ID == "" {
+		b.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/escrow.go
+++ b/internal/models/escrow.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type Escrow struct {
+	ID        string          `gorm:"primaryKey;size:21"`
+	ClientID  string          `gorm:"size:21;not null"`
+	Client    Client          `gorm:"foreignKey:ClientID" json:"-"`
+	AssetID   string          `gorm:"size:21;not null"`
+	Asset     Asset           `gorm:"foreignKey:AssetID" json:"-"`
+	Amount    decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	OfferID   *string         `gorm:"size:21"`
+	Offer     Offer           `gorm:"foreignKey:OfferID" json:"-"`
+	OrderID   *string         `gorm:"size:21"`
+	Order     Order           `gorm:"foreignKey:OrderID" json:"-"`
+	CreatedAt time.Time       `gorm:"autoCreateTime"`
+	UpdatedAt time.Time       `gorm:"autoUpdateTime"`
+}
+
+func (e *Escrow) BeforeCreate(tx *gorm.DB) (err error) {
+	if e.ID == "" {
+		e.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/order.go
+++ b/internal/models/order.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type Order struct {
+	ID              string              `gorm:"primaryKey;size:21"`
+	OfferID         string              `gorm:"size:21;not null"`
+	Offer           Offer               `gorm:"foreignKey:OfferID" json:"-"`
+	BuyerID         string              `gorm:"size:21;not null"`
+	Buyer           Client              `gorm:"foreignKey:BuyerID" json:"-"`
+	SellerID        string              `gorm:"size:21;not null"`
+	Seller          Client              `gorm:"foreignKey:SellerID" json:"-"`
+	FromAssetID     string              `gorm:"size:21;not null"`
+	FromAsset       Asset               `gorm:"foreignKey:FromAssetID" json:"-"`
+	ToAssetID       string              `gorm:"size:21;not null"`
+	ToAsset         Asset               `gorm:"foreignKey:ToAssetID" json:"-"`
+	Amount          decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
+	Price           decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
+	PaymentMethodID string              `gorm:"size:21"`
+	PaymentMethod   ClientPaymentMethod `gorm:"foreignKey:PaymentMethodID" json:"-"`
+	Status          string              `gorm:"type:varchar(20);not null"`
+	IsEscrow        bool                `gorm:"not null;default:false"`
+	ExpiresAt       time.Time           `gorm:"not null"`
+	ReleasedAt      *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+func (o *Order) BeforeCreate(tx *gorm.DB) (err error) {
+	if o.ID == "" {
+		o.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/transaction_in.go
+++ b/internal/models/transaction_in.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type TransactionIn struct {
+	ID        string          `gorm:"primaryKey;size:21"`
+	ClientID  string          `gorm:"size:21;not null"`
+	Client    Client          `gorm:"foreignKey:ClientID" json:"-"`
+	WalletID  string          `gorm:"size:21;not null"`
+	Wallet    Wallet          `gorm:"foreignKey:WalletID" json:"-"`
+	AssetID   string          `gorm:"size:21;not null"`
+	Asset     Asset           `gorm:"foreignKey:AssetID" json:"-"`
+	Amount    decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	Status    string          `gorm:"type:varchar(20);not null"`
+	Data      datatypes.JSON  `gorm:"type:json"`
+	CreatedAt time.Time       `gorm:"autoCreateTime"`
+	UpdatedAt time.Time       `gorm:"autoUpdateTime"`
+}
+
+func (t *TransactionIn) BeforeCreate(tx *gorm.DB) (err error) {
+	if t.ID == "" {
+		t.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/transaction_internal.go
+++ b/internal/models/transaction_internal.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type TransactionInternal struct {
+	ID           string          `gorm:"primaryKey;size:21"`
+	AssetID      string          `gorm:"size:21;not null"`
+	Asset        Asset           `gorm:"foreignKey:AssetID" json:"-"`
+	Amount       decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	OrderInfo    string          `gorm:"type:text"`
+	FromClientID string          `gorm:"size:21"`
+	FromClient   Client          `gorm:"foreignKey:FromClientID" json:"-"`
+	ToClientID   string          `gorm:"size:21"`
+	ToClient     Client          `gorm:"foreignKey:ToClientID" json:"-"`
+	Status       string          `gorm:"type:varchar(20);not null"`
+	Data         datatypes.JSON  `gorm:"type:json"`
+	CreatedAt    time.Time       `gorm:"autoCreateTime"`
+	UpdatedAt    time.Time       `gorm:"autoUpdateTime"`
+}
+
+func (t *TransactionInternal) BeforeCreate(tx *gorm.DB) (err error) {
+	if t.ID == "" {
+		t.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/transaction_out.go
+++ b/internal/models/transaction_out.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type TransactionOut struct {
+	ID          string          `gorm:"primaryKey;size:21"`
+	ClientID    string          `gorm:"size:21;not null"`
+	Client      Client          `gorm:"foreignKey:ClientID" json:"-"`
+	AssetID     string          `gorm:"size:21;not null"`
+	Asset       Asset           `gorm:"foreignKey:AssetID" json:"-"`
+	Amount      decimal.Decimal `gorm:"type:decimal(32,8);not null"`
+	FromAddress string          `gorm:"type:varchar(255)"`
+	ToAddress   string          `gorm:"type:varchar(255)"`
+	Status      string          `gorm:"type:varchar(20);not null"`
+	Data        datatypes.JSON  `gorm:"type:json"`
+	CreatedAt   time.Time       `gorm:"autoCreateTime"`
+	UpdatedAt   time.Time       `gorm:"autoUpdateTime"`
+}
+
+func (t *TransactionOut) BeforeCreate(tx *gorm.DB) (err error) {
+	if t.ID == "" {
+		t.ID, err = utils.GenerateNanoID()
+	}
+	return
+}


### PR DESCRIPTION
## Summary
- добавлены модели Order, Balance, Escrow и транзакций
- реализованы хендлеры и swagger-документация для ордеров, балансов и эскроу
- кошелёк автоматически создаёт запись баланса

## Testing
- `swag init -g cmd/api/main.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e5842e3a083328f268ca09262e21b