### PR TITLE
feat: add btc watcher for deposits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,9 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
+	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
+	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
+	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,13 +13,16 @@ github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
+github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
+github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
+github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=

--- a/internal/btcwatcher/watcher.go
+++ b/internal/btcwatcher/watcher.go
@@ -1,0 +1,109 @@
+package btcwatcher
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/shopspring/decimal"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// Watcher следит за блоками Bitcoin и записывает подтвержденные депозиты.
+type Watcher struct {
+	client *rpcclient.Client
+	db     *gorm.DB
+	params *chaincfg.Params
+}
+
+// New создаёт нового наблюдателя.
+func New(db *gorm.DB, cfg *rpcclient.ConnConfig, params *chaincfg.Params) (*Watcher, error) {
+	if params == nil {
+		params = &chaincfg.MainNetParams
+	}
+	ntfnHandlers := rpcclient.NotificationHandlers{}
+	w := &Watcher{db: db, params: params}
+	ntfnHandlers.OnBlockConnected = func(hash *chainhash.Hash, height int32, t time.Time) {
+		go w.handleBlock(hash)
+	}
+	client, err := rpcclient.New(cfg, &ntfnHandlers)
+	if err != nil {
+		return nil, err
+	}
+	w.client = client
+	return w, nil
+}
+
+// Start запускает подписку на новые блоки.
+func (w *Watcher) Start() error {
+	if err := w.client.NotifyBlocks(); err != nil {
+		return fmt.Errorf("notify blocks: %w", err)
+	}
+	return nil
+}
+
+// handleBlock обрабатывает подключенный блок.
+func (w *Watcher) handleBlock(hash *chainhash.Hash) {
+	block, err := w.client.GetBlock(hash)
+	if err != nil {
+		log.Printf("не удалось получить блок %s: %v", hash, err)
+		return
+	}
+	for _, tx := range block.Transactions {
+		w.processTx(tx, hash.String())
+	}
+}
+
+func (w *Watcher) processTx(tx *wire.MsgTx, blockHash string) {
+	txid := tx.TxHash().String()
+	for i, out := range tx.TxOut {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(out.PkScript, w.params)
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+		for _, addr := range addrs {
+			var wallet models.Wallet
+			if err := w.db.Where("value = ?", addr.EncodeAddress()).First(&wallet).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					continue
+				}
+				log.Printf("ошибка базы данных: %v", err)
+				continue
+			}
+			var existing models.TransactionIn
+			if err := w.db.Where("data ->> 'txid' = ? AND data ->> 'vout' = ?", txid, fmt.Sprintf("%d", i)).First(&existing).Error; err == nil {
+				continue
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Printf("ошибка проверки существующей транзакции: %v", err)
+				continue
+			}
+			amount := decimal.NewFromInt(out.Value).Div(decimal.NewFromInt(1e8))
+			data, _ := json.Marshal(map[string]any{
+				"txid":       txid,
+				"vout":       i,
+				"block_hash": blockHash,
+			})
+			dep := models.TransactionIn{
+				ClientID: wallet.ClientID,
+				WalletID: wallet.ID,
+				AssetID:  wallet.AssetID,
+				Amount:   amount,
+				Status:   "confirmed",
+				Data:     datatypes.JSON(data),
+			}
+			if err := w.db.Create(&dep).Error; err != nil {
+				log.Printf("не удалось сохранить депозит: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add btc watcher that listens to btcd blocks and records deposits

## Testing
- `go test ./internal/db -run . -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f41cda3848332b988b9dcc53f0907