### PR TITLE
feat: add status constants

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -59,7 +59,7 @@ func CreateOrder(db *gorm.DB) gin.HandlerFunc {
 			Amount:          amt,
 			Price:           offer.Price,
 			PaymentMethodID: r.PaymentMethodID,
-			Status:          "WAIT_PAYMENT",
+			Status:          models.OrderStatusWaitPayment,
 			ExpiresAt:       time.Now().Add(time.Duration(offer.OrderExpirationTimeout) * time.Minute),
 		}
 		if offer.FromAsset.Type == "crypto" || offer.ToAsset.Type == "crypto" {

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -74,6 +74,9 @@ func TestOrderHandler(t *testing.T) {
 	if !ord.IsEscrow {
 		t.Fatalf("expected escrow true")
 	}
+	if ord.Status != models.OrderStatusWaitPayment {
+		t.Fatalf("unexpected status %s", ord.Status)
+	}
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/client/orders", nil)

--- a/internal/models/order.go
+++ b/internal/models/order.go
@@ -8,6 +8,16 @@ import (
 	"ptop/internal/utils"
 )
 
+type OrderStatus string
+
+const (
+	OrderStatusWaitPayment OrderStatus = "WAIT_PAYMENT"
+	OrderStatusPaid        OrderStatus = "PAID"
+	OrderStatusReleased    OrderStatus = "RELEASED"
+	OrderStatusCancelled   OrderStatus = "CANCELLED"
+	OrderStatusDispute     OrderStatus = "DISPUTE"
+)
+
 type Order struct {
 	ID              string              `gorm:"primaryKey;size:21"`
 	OfferID         string              `gorm:"size:21;not null"`
@@ -24,7 +34,7 @@ type Order struct {
 	Price           decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
 	PaymentMethodID string              `gorm:"size:21"`
 	PaymentMethod   ClientPaymentMethod `gorm:"foreignKey:PaymentMethodID" json:"-"`
-	Status          string              `gorm:"type:varchar(20);not null"`
+	Status          OrderStatus         `gorm:"type:varchar(20);not null"`
 	IsEscrow        bool                `gorm:"not null;default:false"`
 	ExpiresAt       time.Time           `gorm:"not null"`
 	ReleasedAt      *time.Time

--- a/internal/models/transaction_in.go
+++ b/internal/models/transaction_in.go
@@ -9,19 +9,28 @@ import (
 	"ptop/internal/utils"
 )
 
+type TransactionInStatus string
+
+const (
+	TransactionInStatusPending    TransactionInStatus = "pending"
+	TransactionInStatusProcessing TransactionInStatus = "processing"
+	TransactionInStatusConfirmed  TransactionInStatus = "confirmed"
+	TransactionInStatusFailed     TransactionInStatus = "failed"
+)
+
 type TransactionIn struct {
-	ID        string          `gorm:"primaryKey;size:21"`
-	ClientID  string          `gorm:"size:21;not null"`
-	Client    Client          `gorm:"foreignKey:ClientID" json:"-"`
-	WalletID  string          `gorm:"size:21;not null"`
-	Wallet    Wallet          `gorm:"foreignKey:WalletID" json:"-"`
-	AssetID   string          `gorm:"size:21;not null"`
-	Asset     Asset           `gorm:"foreignKey:AssetID" json:"-"`
-	Amount    decimal.Decimal `gorm:"type:decimal(32,8);not null"`
-	Status    string          `gorm:"type:varchar(20);not null"`
-	Data      datatypes.JSON  `gorm:"type:json"`
-	CreatedAt time.Time       `gorm:"autoCreateTime"`
-	UpdatedAt time.Time       `gorm:"autoUpdateTime"`
+	ID        string              `gorm:"primaryKey;size:21"`
+	ClientID  string              `gorm:"size:21;not null"`
+	Client    Client              `gorm:"foreignKey:ClientID" json:"-"`
+	WalletID  string              `gorm:"size:21;not null"`
+	Wallet    Wallet              `gorm:"foreignKey:WalletID" json:"-"`
+	AssetID   string              `gorm:"size:21;not null"`
+	Asset     Asset               `gorm:"foreignKey:AssetID" json:"-"`
+	Amount    decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
+	Status    TransactionInStatus `gorm:"type:varchar(20);not null"`
+	Data      datatypes.JSON      `gorm:"type:json"`
+	CreatedAt time.Time           `gorm:"autoCreateTime"`
+	UpdatedAt time.Time           `gorm:"autoUpdateTime"`
 }
 
 func (t *TransactionIn) BeforeCreate(tx *gorm.DB) (err error) {

--- a/internal/models/transaction_internal.go
+++ b/internal/models/transaction_internal.go
@@ -9,20 +9,28 @@ import (
 	"ptop/internal/utils"
 )
 
+type TransactionInternalStatus string
+
+const (
+	TransactionInternalStatusProcessing TransactionInternalStatus = "processing"
+	TransactionInternalStatusConfirmed  TransactionInternalStatus = "confirmed"
+	TransactionInternalStatusFailed     TransactionInternalStatus = "failed"
+)
+
 type TransactionInternal struct {
-	ID           string          `gorm:"primaryKey;size:21"`
-	AssetID      string          `gorm:"size:21;not null"`
-	Asset        Asset           `gorm:"foreignKey:AssetID" json:"-"`
-	Amount       decimal.Decimal `gorm:"type:decimal(32,8);not null"`
-	OrderInfo    string          `gorm:"type:text"`
-	FromClientID string          `gorm:"size:21"`
-	FromClient   Client          `gorm:"foreignKey:FromClientID" json:"-"`
-	ToClientID   string          `gorm:"size:21"`
-	ToClient     Client          `gorm:"foreignKey:ToClientID" json:"-"`
-	Status       string          `gorm:"type:varchar(20);not null"`
-	Data         datatypes.JSON  `gorm:"type:json"`
-	CreatedAt    time.Time       `gorm:"autoCreateTime"`
-	UpdatedAt    time.Time       `gorm:"autoUpdateTime"`
+	ID           string                    `gorm:"primaryKey;size:21"`
+	AssetID      string                    `gorm:"size:21;not null"`
+	Asset        Asset                     `gorm:"foreignKey:AssetID" json:"-"`
+	Amount       decimal.Decimal           `gorm:"type:decimal(32,8);not null"`
+	OrderInfo    string                    `gorm:"type:text"`
+	FromClientID string                    `gorm:"size:21"`
+	FromClient   Client                    `gorm:"foreignKey:FromClientID" json:"-"`
+	ToClientID   string                    `gorm:"size:21"`
+	ToClient     Client                    `gorm:"foreignKey:ToClientID" json:"-"`
+	Status       TransactionInternalStatus `gorm:"type:varchar(20);not null"`
+	Data         datatypes.JSON            `gorm:"type:json"`
+	CreatedAt    time.Time                 `gorm:"autoCreateTime"`
+	UpdatedAt    time.Time                 `gorm:"autoUpdateTime"`
 }
 
 func (t *TransactionInternal) BeforeCreate(tx *gorm.DB) (err error) {

--- a/internal/models/transaction_out.go
+++ b/internal/models/transaction_out.go
@@ -9,19 +9,29 @@ import (
 	"ptop/internal/utils"
 )
 
+type TransactionOutStatus string
+
+const (
+	TransactionOutStatusPending    TransactionOutStatus = "pending"
+	TransactionOutStatusProcessing TransactionOutStatus = "processing"
+	TransactionOutStatusConfirmed  TransactionOutStatus = "confirmed"
+	TransactionOutStatusFailed     TransactionOutStatus = "failed"
+	TransactionOutStatusCancelled  TransactionOutStatus = "cancelled"
+)
+
 type TransactionOut struct {
-	ID          string          `gorm:"primaryKey;size:21"`
-	ClientID    string          `gorm:"size:21;not null"`
-	Client      Client          `gorm:"foreignKey:ClientID" json:"-"`
-	AssetID     string          `gorm:"size:21;not null"`
-	Asset       Asset           `gorm:"foreignKey:AssetID" json:"-"`
-	Amount      decimal.Decimal `gorm:"type:decimal(32,8);not null"`
-	FromAddress string          `gorm:"type:varchar(255)"`
-	ToAddress   string          `gorm:"type:varchar(255)"`
-	Status      string          `gorm:"type:varchar(20);not null"`
-	Data        datatypes.JSON  `gorm:"type:json"`
-	CreatedAt   time.Time       `gorm:"autoCreateTime"`
-	UpdatedAt   time.Time       `gorm:"autoUpdateTime"`
+	ID          string               `gorm:"primaryKey;size:21"`
+	ClientID    string               `gorm:"size:21;not null"`
+	Client      Client               `gorm:"foreignKey:ClientID" json:"-"`
+	AssetID     string               `gorm:"size:21;not null"`
+	Asset       Asset                `gorm:"foreignKey:AssetID" json:"-"`
+	Amount      decimal.Decimal      `gorm:"type:decimal(32,8);not null"`
+	FromAddress string               `gorm:"type:varchar(255)"`
+	ToAddress   string               `gorm:"type:varchar(255)"`
+	Status      TransactionOutStatus `gorm:"type:varchar(20);not null"`
+	Data        datatypes.JSON       `gorm:"type:json"`
+	CreatedAt   time.Time            `gorm:"autoCreateTime"`
+	UpdatedAt   time.Time            `gorm:"autoUpdateTime"`
 }
 
 func (t *TransactionOut) BeforeCreate(tx *gorm.DB) (err error) {


### PR DESCRIPTION
## Summary
- add typed status constants for orders and transactions
- use constants in order handler and test

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688f3d7e1d2c8332971d0607d9775ab6