### PR TITLE
Remove offer payment methods and rename order field

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1227,7 +1227,7 @@ const docTemplate = `{
                 "offer_id": {
                     "type": "string"
                 },
-                "payment_method_id": {
+                "client_payment_method_id": {
                     "type": "string"
                 }
             }
@@ -1523,7 +1523,7 @@ const docTemplate = `{
                 "offerID": {
                     "type": "string"
                 },
-                "paymentMethodID": {
+                "clientPaymentMethodID": {
                     "type": "string"
                 },
                 "price": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1220,7 +1220,7 @@
                 "offer_id": {
                     "type": "string"
                 },
-                "payment_method_id": {
+                "client_payment_method_id": {
                     "type": "string"
                 }
             }
@@ -1516,7 +1516,7 @@
                 "offerID": {
                     "type": "string"
                 },
-                "paymentMethodID": {
+                "clientPaymentMethodID": {
                     "type": "string"
                 },
                 "price": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -91,7 +91,7 @@ definitions:
         type: string
       offer_id:
         type: string
-      payment_method_id:
+      client_payment_method_id:
         type: string
     type: object
   handlers.ProfileResponse:
@@ -283,7 +283,7 @@ definitions:
         type: boolean
       offerID:
         type: string
-      paymentMethodID:
+      clientPaymentMethodID:
         type: string
       price:
         type: number

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -12,9 +12,9 @@ import (
 )
 
 type OrderRequest struct {
-	OfferID         string `json:"offer_id"`
-	Amount          string `json:"amount"`
-	PaymentMethodID string `json:"payment_method_id"`
+	OfferID               string `json:"offer_id"`
+	Amount                string `json:"amount"`
+	ClientPaymentMethodID string `json:"client_payment_method_id"`
 }
 
 // CreateOrder godoc
@@ -51,16 +51,16 @@ func CreateOrder(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		order := models.Order{
-			OfferID:         offer.ID,
-			BuyerID:         clientID,
-			SellerID:        offer.ClientID,
-			FromAssetID:     offer.FromAssetID,
-			ToAssetID:       offer.ToAssetID,
-			Amount:          amt,
-			Price:           offer.Price,
-			PaymentMethodID: r.PaymentMethodID,
-			Status:          models.OrderStatusWaitPayment,
-			ExpiresAt:       time.Now().Add(time.Duration(offer.OrderExpirationTimeout) * time.Minute),
+			OfferID:               offer.ID,
+			BuyerID:               clientID,
+			SellerID:              offer.ClientID,
+			FromAssetID:           offer.FromAssetID,
+			ToAssetID:             offer.ToAssetID,
+			Amount:                amt,
+			Price:                 offer.Price,
+			ClientPaymentMethodID: r.ClientPaymentMethodID,
+			Status:                models.OrderStatusWaitPayment,
+			ExpiresAt:             time.Now().Add(time.Duration(offer.OrderExpirationTimeout) * time.Minute),
 		}
 		if offer.FromAsset.Type == "crypto" || offer.ToAsset.Type == "crypto" {
 			order.IsEscrow = true

--- a/internal/models/offer.go
+++ b/internal/models/offer.go
@@ -26,7 +26,6 @@ type Offer struct {
 	IsEnabled              bool                  `gorm:"not null;default:false"`
 	ClientID               string                `gorm:"size:21;not null"`
 	Client                 Client                `gorm:"foreignKey:ClientID" json:"-"`
-	PaymentMethods         []PaymentMethod       `gorm:"many2many:offer_payment_methods" json:"-"`
 	ClientPaymentMethods   []ClientPaymentMethod `gorm:"many2many:offer_client_payment_methods" json:"-"`
 	CreatedAt              time.Time
 	UpdatedAt              time.Time

--- a/internal/models/order.go
+++ b/internal/models/order.go
@@ -19,27 +19,27 @@ const (
 )
 
 type Order struct {
-	ID              string              `gorm:"primaryKey;size:21"`
-	OfferID         string              `gorm:"size:21;not null"`
-	Offer           Offer               `gorm:"foreignKey:OfferID" json:"-"`
-	BuyerID         string              `gorm:"size:21;not null"`
-	Buyer           Client              `gorm:"foreignKey:BuyerID" json:"-"`
-	SellerID        string              `gorm:"size:21;not null"`
-	Seller          Client              `gorm:"foreignKey:SellerID" json:"-"`
-	FromAssetID     string              `gorm:"size:21;not null"`
-	FromAsset       Asset               `gorm:"foreignKey:FromAssetID" json:"-"`
-	ToAssetID       string              `gorm:"size:21;not null"`
-	ToAsset         Asset               `gorm:"foreignKey:ToAssetID" json:"-"`
-	Amount          decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
-	Price           decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
-	PaymentMethodID string              `gorm:"size:21"`
-	PaymentMethod   ClientPaymentMethod `gorm:"foreignKey:PaymentMethodID" json:"-"`
-	Status          OrderStatus         `gorm:"type:varchar(20);not null"`
-	IsEscrow        bool                `gorm:"not null;default:false"`
-	ExpiresAt       time.Time           `gorm:"not null"`
-	ReleasedAt      *time.Time
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID                    string              `gorm:"primaryKey;size:21"`
+	OfferID               string              `gorm:"size:21;not null"`
+	Offer                 Offer               `gorm:"foreignKey:OfferID" json:"-"`
+	BuyerID               string              `gorm:"size:21;not null"`
+	Buyer                 Client              `gorm:"foreignKey:BuyerID" json:"-"`
+	SellerID              string              `gorm:"size:21;not null"`
+	Seller                Client              `gorm:"foreignKey:SellerID" json:"-"`
+	FromAssetID           string              `gorm:"size:21;not null"`
+	FromAsset             Asset               `gorm:"foreignKey:FromAssetID" json:"-"`
+	ToAssetID             string              `gorm:"size:21;not null"`
+	ToAsset               Asset               `gorm:"foreignKey:ToAssetID" json:"-"`
+	Amount                decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
+	Price                 decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
+	ClientPaymentMethodID string              `gorm:"size:21"`
+	ClientPaymentMethod   ClientPaymentMethod `gorm:"foreignKey:ClientPaymentMethodID" json:"-"`
+	Status                OrderStatus         `gorm:"type:varchar(20);not null"`
+	IsEscrow              bool                `gorm:"not null;default:false"`
+	ExpiresAt             time.Time           `gorm:"not null"`
+	ReleasedAt            *time.Time
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 func (o *Order) BeforeCreate(tx *gorm.DB) (err error) {


### PR DESCRIPTION
## Summary
- drop PaymentMethods from offers and rely on client payment methods
- rename order.PaymentMethodID to ClientPaymentMethodID
- update swagger docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f4585954483328d47d68afc781ab3