### PR TITLE
feat: add monero watcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/joho/godotenv v1.5.1
 	github.com/matoous/go-nanoid/v2 v2.1.0
+	github.com/omani/go-monero-rpc-client v0.0.0-20250208023320-c16fcacc53ad
 	github.com/pquerna/otp v1.5.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/swaggo/files v1.0.1
@@ -59,6 +60,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/rpc v1.2.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
+github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
@@ -230,6 +232,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/omani/go-monero-rpc-client v0.0.0-20250208023320-c16fcacc53ad h1:U8XS+wsI8wemKPcC9jiYTKSHHDFP89v8zUpB1NWimZ8=
+github.com/omani/go-monero-rpc-client v0.0.0-20250208023320-c16fcacc53ad/go.mod h1:nKM9PUn04IfHgWzklrtrLEV7KD5Cjwda4N6c+6DGcYA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/internal/xmrwatcher/watcher.go
+++ b/internal/xmrwatcher/watcher.go
@@ -1,0 +1,121 @@
+package xmrwatcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/omani/go-monero-rpc-client/wallet"
+	"github.com/shopspring/decimal"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// Watcher отслеживает входящие транзакции Monero и сохраняет их в базе данных.
+type Watcher struct {
+	client       wallet.Client
+	db           *gorm.DB
+	pollInterval time.Duration
+}
+
+// New создаёт нового наблюдателя.
+func New(db *gorm.DB, rpcURL string, interval time.Duration) *Watcher {
+	if interval == 0 {
+		interval = time.Minute
+	}
+	cl := wallet.New(wallet.Config{Address: rpcURL})
+	return &Watcher{client: cl, db: db, pollInterval: interval}
+}
+
+// Start запускает периодический опрос get_transfers.
+func (w *Watcher) Start() {
+	go w.check()
+	ticker := time.NewTicker(w.pollInterval)
+	go func() {
+		for range ticker.C {
+			w.check()
+		}
+	}()
+}
+
+func (w *Watcher) check() {
+	// Получаем все кошельки XMR.
+	var wallets []models.Wallet
+	if err := w.db.Joins("JOIN assets ON wallets.asset_id = assets.id").Where("assets.name LIKE ?", "XMR%").Find(&wallets).Error; err != nil {
+		log.Printf("ошибка базы данных: %v", err)
+		return
+	}
+	if len(wallets) == 0 {
+		return
+	}
+	subMap := make(map[uint64]models.Wallet, len(wallets))
+	indices := make([]uint64, 0, len(wallets))
+	for _, wal := range wallets {
+		subMap[uint64(wal.DerivationIndex)] = wal
+		indices = append(indices, uint64(wal.DerivationIndex))
+	}
+
+	res, err := w.client.GetTransfers(&wallet.RequestGetTransfers{
+		In:             true,
+		Pending:        true,
+		AccountIndex:   0,
+		SubaddrIndices: indices,
+	})
+	if err != nil {
+		log.Printf("get_transfers error: %v", err)
+		return
+	}
+
+	for _, tr := range res.Pending {
+		w.handleTransfer(tr, subMap, models.TransactionInStatusPending)
+	}
+	for _, tr := range res.In {
+		w.handleTransfer(tr, subMap, models.TransactionInStatusConfirmed)
+	}
+}
+
+func (w *Watcher) handleTransfer(tr *wallet.Transfer, subMap map[uint64]models.Wallet, status models.TransactionInStatus) {
+	wal, ok := subMap[tr.SubaddrIndex.Minor]
+	if !ok {
+		return
+	}
+	var existing models.TransactionIn
+	err := w.db.Where("data ->> 'txid' = ? AND data ->> 'subaddr_index' = ?", tr.TxID, fmt.Sprintf("%d", tr.SubaddrIndex.Minor)).First(&existing).Error
+	if err == nil {
+		if existing.Status != status && status == models.TransactionInStatusConfirmed {
+			data, _ := json.Marshal(map[string]any{
+				"txid":          tr.TxID,
+				"subaddr_index": tr.SubaddrIndex.Minor,
+				"confirmations": tr.Confirmations,
+			})
+			if err := w.db.Model(&existing).Updates(map[string]any{"status": status, "data": datatypes.JSON(data)}).Error; err != nil {
+				log.Printf("не удалось обновить депозит: %v", err)
+			}
+		}
+		return
+	}
+	if err != nil && err != gorm.ErrRecordNotFound {
+		log.Printf("ошибка проверки существующей транзакции: %v", err)
+		return
+	}
+	amount := decimal.NewFromInt(int64(tr.Amount)).Div(decimal.NewFromInt(1e12))
+	data, _ := json.Marshal(map[string]any{
+		"txid":          tr.TxID,
+		"subaddr_index": tr.SubaddrIndex.Minor,
+		"confirmations": tr.Confirmations,
+	})
+	dep := models.TransactionIn{
+		ClientID: wal.ClientID,
+		WalletID: wal.ID,
+		AssetID:  wal.AssetID,
+		Amount:   amount,
+		Status:   status,
+		Data:     datatypes.JSON(data),
+	}
+	if err := w.db.Create(&dep).Error; err != nil {
+		log.Printf("не удалось сохранить депозит: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add XMR watcher using go-monero-rpc get_transfers
- store incoming transfers with confirmation status

## Testing
- `go test ./internal/xmrwatcher`

------
https://chatgpt.com/codex/tasks/task_e_688f473f125083328423c3b927476b84