### PR TITLE
Добавлен debug-режим для наблюдателей и API для фейковых депозитов

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DSN                      string
 	TokenTypeTTL             map[string]time.Duration
 	MaxActiveOffersPerClient int
+	WatchersDebug            bool
 	// Другие поля, например:
 	// JWTSecret string
 	// Timezone  string
@@ -43,6 +44,8 @@ func Load() (*Config, error) {
 		maxOffers = v
 	}
 
+	debug := os.Getenv("WATCHERS_DEBUG") == "1"
+
 	return &Config{
 		Port: port,
 		DSN:  dsn,
@@ -51,6 +54,7 @@ func Load() (*Config, error) {
 			"refresh": refreshTTL,
 		},
 		MaxActiveOffersPerClient: maxOffers,
+		WatchersDebug:            debug,
 		// JWTSecret: os.Getenv("JWT_SECRET"),
 		// Timezone:  os.Getenv("TIMEZONE"),
 	}, nil

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -991,6 +991,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/debug/deposit": {
+            "post": {
+                "description": "Создаёт фейковый депозит на указанный кошелёк",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "debug"
+                ],
+                "summary": "Тестовый депозит",
+                "parameters": [
+                    {
+                        "description": "Запрос",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DebugDepositRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -1131,6 +1180,21 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.DebugDepositRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "wallet_id"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "wallet_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
@@ -1224,10 +1288,10 @@ const docTemplate = `{
                 "amount": {
                     "type": "string"
                 },
-                "offer_id": {
+                "client_payment_method_id": {
                     "type": "string"
                 },
-                "client_payment_method_id": {
+                "offer_id": {
                     "type": "string"
                 }
             }
@@ -1508,6 +1572,9 @@ const docTemplate = `{
                 "buyerID": {
                     "type": "string"
                 },
+                "clientPaymentMethodID": {
+                    "type": "string"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -1524,9 +1591,6 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "offerID": {
-                    "type": "string"
-                },
-                "clientPaymentMethodID": {
                     "type": "string"
                 },
                 "price": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -984,6 +984,55 @@
                 }
             }
         },
+        "/debug/deposit": {
+            "post": {
+                "description": "Создаёт фейковый депозит на указанный кошелёк",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "debug"
+                ],
+                "summary": "Тестовый депозит",
+                "parameters": [
+                    {
+                        "description": "Запрос",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DebugDepositRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -1124,6 +1173,21 @@
                 }
             }
         },
+        "handlers.DebugDepositRequest": {
+            "type": "object",
+            "required": [
+                "amount",
+                "wallet_id"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "wallet_id": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
@@ -1217,10 +1281,10 @@
                 "amount": {
                     "type": "string"
                 },
-                "offer_id": {
+                "client_payment_method_id": {
                     "type": "string"
                 },
-                "client_payment_method_id": {
+                "offer_id": {
                     "type": "string"
                 }
             }
@@ -1501,6 +1565,9 @@
                 "buyerID": {
                     "type": "string"
                 },
+                "clientPaymentMethodID": {
+                    "type": "string"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -1517,9 +1584,6 @@
                     "type": "boolean"
                 },
                 "offerID": {
-                    "type": "string"
-                },
-                "clientPaymentMethodID": {
                     "type": "string"
                 },
                 "price": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -29,6 +29,16 @@ definitions:
       post_code:
         type: string
     type: object
+  handlers.DebugDepositRequest:
+    properties:
+      amount:
+        type: string
+      wallet_id:
+        type: string
+    required:
+    - amount
+    - wallet_id
+    type: object
   handlers.Enable2FARequest:
     properties:
       password:
@@ -89,9 +99,9 @@ definitions:
     properties:
       amount:
         type: string
-      offer_id:
-        type: string
       client_payment_method_id:
+        type: string
+      offer_id:
         type: string
     type: object
   handlers.ProfileResponse:
@@ -273,6 +283,8 @@ definitions:
         type: number
       buyerID:
         type: string
+      clientPaymentMethodID:
+        type: string
       createdAt:
         type: string
       expiresAt:
@@ -284,8 +296,6 @@ definitions:
       isEscrow:
         type: boolean
       offerID:
-        type: string
-      clientPaymentMethodID:
         type: string
       price:
         type: number
@@ -954,6 +964,38 @@ paths:
       summary: Список стран
       tags:
       - reference
+  /debug/deposit:
+    post:
+      consumes:
+      - application/json
+      description: Создаёт фейковый депозит на указанный кошелёк
+      parameters:
+      - description: Запрос
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.DebugDepositRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Тестовый депозит
+      tags:
+      - debug
   /health:
     get:
       produces:

--- a/internal/btcwatcher/watcher_test.go
+++ b/internal/btcwatcher/watcher_test.go
@@ -1,0 +1,45 @@
+package btcwatcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+func TestWatcherDebugDeposit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:btc_debug?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Client{}, &models.Asset{}, &models.Wallet{}, &models.TransactionIn{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	client := models.Client{Username: "u"}
+	db.Create(&client)
+	asset := models.Asset{Name: "BTC"}
+	db.Create(&asset)
+	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "addr", DerivationIndex: 1}
+	db.Create(&wallet)
+
+	w, err := New(db, nil, nil, true)
+	if err != nil {
+		t.Fatalf("watcher: %v", err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	w.TriggerDeposit(wallet.ID, decimal.RequireFromString("2"))
+	time.Sleep(50 * time.Millisecond)
+	var tx models.TransactionIn
+	if err := db.First(&tx).Error; err != nil {
+		t.Fatalf("tx: %v", err)
+	}
+	if !tx.Amount.Equal(decimal.RequireFromString("2")) {
+		t.Fatalf("amount %s", tx.Amount)
+	}
+}

--- a/internal/ethwatcher/watcher_test.go
+++ b/internal/ethwatcher/watcher_test.go
@@ -1,0 +1,45 @@
+package ethwatcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+func TestWatcherDebugDeposit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:eth_debug?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Client{}, &models.Asset{}, &models.Wallet{}, &models.TransactionIn{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	client := models.Client{Username: "u"}
+	db.Create(&client)
+	asset := models.Asset{Name: "ETH"}
+	db.Create(&asset)
+	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "0x1", DerivationIndex: 1}
+	db.Create(&wallet)
+
+	w, err := New(db, "", true)
+	if err != nil {
+		t.Fatalf("watcher: %v", err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	w.TriggerDeposit(wallet.ID, decimal.RequireFromString("3"))
+	time.Sleep(50 * time.Millisecond)
+	var tx models.TransactionIn
+	if err := db.First(&tx).Error; err != nil {
+		t.Fatalf("tx: %v", err)
+	}
+	if !tx.Amount.Equal(decimal.RequireFromString("3")) {
+		t.Fatalf("amount %s", tx.Amount)
+	}
+}

--- a/internal/handlers/debug.go
+++ b/internal/handlers/debug.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+type DebugDepositor interface {
+	TriggerDeposit(walletID string, amount decimal.Decimal)
+}
+
+type DebugDepositRequest struct {
+	WalletID string `json:"wallet_id" binding:"required"`
+	Amount   string `json:"amount" binding:"required"`
+}
+
+// DebugDeposit godoc
+// @Summary      Тестовый депозит
+// @Description  Создаёт фейковый депозит на указанный кошелёк
+// @Tags         debug
+// @Accept       json
+// @Produce      json
+// @Param        request body DebugDepositRequest true "Запрос"
+// @Success      204
+// @Failure      400 {object} map[string]string
+// @Failure      404 {object} map[string]string
+// @Router       /debug/deposit [post]
+func DebugDeposit(db *gorm.DB, watchers map[string]DebugDepositor) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req DebugDepositRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		amt, err := decimal.NewFromString(req.Amount)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid amount"})
+			return
+		}
+		var wal models.Wallet
+		if err := db.Preload("Asset").Where("id = ?", req.WalletID).First(&wal).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "wallet not found"})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+			return
+		}
+		var watcher DebugDepositor
+		name := strings.ToUpper(wal.Asset.Name)
+		switch {
+		case strings.HasPrefix(name, "BTC"):
+			watcher = watchers["BTC"]
+		case strings.HasPrefix(name, "ETH"):
+			watcher = watchers["ETH"]
+		case strings.HasPrefix(name, "XMR"):
+			watcher = watchers["XMR"]
+		}
+		if watcher == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "watcher not available"})
+			return
+		}
+		watcher.TriggerDeposit(wal.ID, amt)
+		c.Status(http.StatusNoContent)
+	}
+}

--- a/internal/handlers/debug_test.go
+++ b/internal/handlers/debug_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/btcwatcher"
+	"ptop/internal/models"
+)
+
+func TestDebugDeposit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open("file:test_debug?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Client{}, &models.Asset{}, &models.Wallet{}, &models.TransactionIn{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	client := models.Client{Username: "u"}
+	if err := db.Create(&client).Error; err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	asset := models.Asset{Name: "BTC"}
+	if err := db.Create(&asset).Error; err != nil {
+		t.Fatalf("create asset: %v", err)
+	}
+	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "addr", DerivationIndex: 1}
+	if err := db.Create(&wallet).Error; err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	w, err := btcwatcher.New(db, nil, nil, true)
+	if err != nil {
+		t.Fatalf("watcher: %v", err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	watchers := map[string]DebugDepositor{"BTC": w}
+	r := gin.Default()
+	r.POST("/debug/deposit", DebugDeposit(db, watchers))
+
+	body, _ := json.Marshal(map[string]string{"wallet_id": wallet.ID, "amount": "1"})
+	req := httptest.NewRequest(http.MethodPost, "/debug/deposit", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("status %d", resp.Code)
+	}
+	time.Sleep(50 * time.Millisecond)
+	var tx models.TransactionIn
+	if err := db.First(&tx).Error; err != nil {
+		t.Fatalf("tx: %v", err)
+	}
+	if !tx.Amount.Equal(decimal.RequireFromString("1")) {
+		t.Fatalf("amount %s", tx.Amount)
+	}
+}

--- a/internal/xmrwatcher/watcher_test.go
+++ b/internal/xmrwatcher/watcher_test.go
@@ -1,0 +1,40 @@
+package xmrwatcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+func TestWatcherDebugDeposit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:xmr_debug?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Client{}, &models.Asset{}, &models.Wallet{}, &models.TransactionIn{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	client := models.Client{Username: "u"}
+	db.Create(&client)
+	asset := models.Asset{Name: "XMR"}
+	db.Create(&asset)
+	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "subaddr", DerivationIndex: 2}
+	db.Create(&wallet)
+
+	w := New(db, "", time.Second, true)
+	w.Start()
+	w.TriggerDeposit(wallet.ID, decimal.RequireFromString("4"))
+	time.Sleep(50 * time.Millisecond)
+	var tx models.TransactionIn
+	if err := db.First(&tx).Error; err != nil {
+		t.Fatalf("tx: %v", err)
+	}
+	if !tx.Amount.Equal(decimal.RequireFromString("4")) {
+		t.Fatalf("amount %s", tx.Amount)
+	}
+}


### PR DESCRIPTION
## Сводка
- Добавлен debug-режим для наблюдателей BTC/ETH/XMR с внутренними каналами для генерации депозитов
- Реализован endpoint `/debug/deposit` для ручного триггера фейковых депозитов
- Добавлены тесты для наблюдателей и нового handler

## Тестирование
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f4ac0d6d483328e9ea9c40755d8fe