### PR TITLE
Добавлены RPC-параметры для наблюдателей

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 DB_DSN=postgres://ptop:ptop@localhost:5432/ptop?sslmode=disable
 PORT=8080
+BTC_RPC_HOST=127.0.0.1:8332
+BTC_RPC_USER=user
+BTC_RPC_PASS=pass
+ETH_RPC_URL=http://localhost:8545
+MONERO_RPC_URL=http://localhost:18082
 # любые другие настройки
 # JWT_SECRET=supersecretkey
 # TIMEZONE=Europe/Warsaw

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-Rest api на golang, gin, postgresql, GORN ORM
+# PTOP API
+
+Rest api на golang, gin, postgresql, GORN ORM.
+
+## Переменные окружения
+
+| Переменная | Описание |
+|------------|----------|
+| `DB_DSN` | строка подключения к базе данных |
+| `PORT` | порт HTTP-сервера (по умолчанию 8080) |
+| `BTC_RPC_HOST` | адрес Bitcoin RPC |
+| `BTC_RPC_USER` | логин Bitcoin RPC |
+| `BTC_RPC_PASS` | пароль Bitcoin RPC |
+| `ETH_RPC_URL` | URL Ethereum RPC |
+| `MONERO_RPC_URL` | URL Monero RPC |
+

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -86,21 +86,24 @@ func main() {
 	api.POST("/client/offers/:id/disable", handlers.DisableOffer(gormDB))
 
 	if cfg.WatchersDebug {
-		btcW, err := btcwatcher.New(gormDB, nil, nil, true)
+		btcW, err := btcwatcher.New(gormDB, cfg.BtcRPCHost, cfg.BtcRPCUser, cfg.BtcRPCPass, nil, true)
 		if err != nil {
 			log.Fatalf("btc watcher: %v", err)
 		}
 		if err := btcW.Start(); err != nil {
 			log.Fatalf("btc watcher start: %v", err)
 		}
-		ethW, err := ethwatcher.New(gormDB, "", true)
+		ethW, err := ethwatcher.New(gormDB, cfg.EthRPCURL, true)
 		if err != nil {
 			log.Fatalf("eth watcher: %v", err)
 		}
 		if err := ethW.Start(); err != nil {
 			log.Fatalf("eth watcher start: %v", err)
 		}
-		xmrW := xmrwatcher.New(gormDB, "", 0, true)
+		xmrW, err := xmrwatcher.New(gormDB, cfg.MoneroRPCURL, 0, true)
+		if err != nil {
+			log.Fatalf("xmr watcher: %v", err)
+		}
 		xmrW.Start()
 		watchers := map[string]handlers.DebugDepositor{
 			"BTC": btcW,

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	TokenTypeTTL             map[string]time.Duration
 	MaxActiveOffersPerClient int
 	WatchersDebug            bool
+	BtcRPCHost               string
+	BtcRPCUser               string
+	BtcRPCPass               string
+	EthRPCURL                string
+	MoneroRPCURL             string
 	// Другие поля, например:
 	// JWTSecret string
 	// Timezone  string
@@ -46,6 +51,12 @@ func Load() (*Config, error) {
 
 	debug := os.Getenv("WATCHERS_DEBUG") == "1"
 
+	btcHost := os.Getenv("BTC_RPC_HOST")
+	btcUser := os.Getenv("BTC_RPC_USER")
+	btcPass := os.Getenv("BTC_RPC_PASS")
+	ethURL := os.Getenv("ETH_RPC_URL")
+	moneroURL := os.Getenv("MONERO_RPC_URL")
+
 	return &Config{
 		Port: port,
 		DSN:  dsn,
@@ -55,6 +66,11 @@ func Load() (*Config, error) {
 		},
 		MaxActiveOffersPerClient: maxOffers,
 		WatchersDebug:            debug,
+		BtcRPCHost:               btcHost,
+		BtcRPCUser:               btcUser,
+		BtcRPCPass:               btcPass,
+		EthRPCURL:                ethURL,
+		MoneroRPCURL:             moneroURL,
 		// JWTSecret: os.Getenv("JWT_SECRET"),
 		// Timezone:  os.Getenv("TIMEZONE"),
 	}, nil

--- a/internal/btcwatcher/watcher.go
+++ b/internal/btcwatcher/watcher.go
@@ -34,7 +34,7 @@ type debugDeposit struct {
 }
 
 // New создаёт нового наблюдателя.
-func New(db *gorm.DB, cfg *rpcclient.ConnConfig, params *chaincfg.Params, debug bool) (*Watcher, error) {
+func New(db *gorm.DB, host, user, pass string, params *chaincfg.Params, debug bool) (*Watcher, error) {
 	if params == nil {
 		params = &chaincfg.MainNetParams
 	}
@@ -42,6 +42,16 @@ func New(db *gorm.DB, cfg *rpcclient.ConnConfig, params *chaincfg.Params, debug 
 	if debug {
 		w.debugCh = make(chan debugDeposit)
 		return w, nil
+	}
+	if host == "" {
+		return nil, fmt.Errorf("btc rpc host required")
+	}
+	cfg := &rpcclient.ConnConfig{
+		Host:         host,
+		User:         user,
+		Pass:         pass,
+		HTTPPostMode: true,
+		DisableTLS:   true,
 	}
 	ntfnHandlers := rpcclient.NotificationHandlers{}
 	ntfnHandlers.OnBlockConnected = func(hash *chainhash.Hash, height int32, t time.Time) {

--- a/internal/btcwatcher/watcher_test.go
+++ b/internal/btcwatcher/watcher_test.go
@@ -26,7 +26,7 @@ func TestWatcherDebugDeposit(t *testing.T) {
 	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "addr", DerivationIndex: 1}
 	db.Create(&wallet)
 
-	w, err := New(db, nil, nil, true)
+	w, err := New(db, "", "", "", nil, true)
 	if err != nil {
 		t.Fatalf("watcher: %v", err)
 	}

--- a/internal/ethwatcher/watcher.go
+++ b/internal/ethwatcher/watcher.go
@@ -60,6 +60,9 @@ func New(db *gorm.DB, rpcURL string, debug bool) (*Watcher, error) {
 		w.debugCh = make(chan debugDeposit)
 		return w, nil
 	}
+	if rpcURL == "" {
+		return nil, fmt.Errorf("eth rpc url required")
+	}
 	client, err := ethclient.Dial(rpcURL)
 	if err != nil {
 		return nil, err

--- a/internal/handlers/debug_test.go
+++ b/internal/handlers/debug_test.go
@@ -38,7 +38,7 @@ func TestDebugDeposit(t *testing.T) {
 	if err := db.Create(&wallet).Error; err != nil {
 		t.Fatalf("create wallet: %v", err)
 	}
-	w, err := btcwatcher.New(db, nil, nil, true)
+	w, err := btcwatcher.New(db, "", "", "", nil, true)
 	if err != nil {
 		t.Fatalf("watcher: %v", err)
 	}

--- a/internal/xmrwatcher/watcher.go
+++ b/internal/xmrwatcher/watcher.go
@@ -29,17 +29,20 @@ type debugDeposit struct {
 }
 
 // New создаёт нового наблюдателя.
-func New(db *gorm.DB, rpcURL string, interval time.Duration, debug bool) *Watcher {
+func New(db *gorm.DB, rpcURL string, interval time.Duration, debug bool) (*Watcher, error) {
 	if interval == 0 {
 		interval = time.Minute
 	}
 	w := &Watcher{db: db, pollInterval: interval, debug: debug}
 	if debug {
 		w.debugCh = make(chan debugDeposit)
-		return w
+		return w, nil
+	}
+	if rpcURL == "" {
+		return nil, fmt.Errorf("monero rpc url required")
 	}
 	w.client = wallet.New(wallet.Config{Address: rpcURL})
-	return w
+	return w, nil
 }
 
 // Start запускает периодический опрос get_transfers.

--- a/internal/xmrwatcher/watcher_test.go
+++ b/internal/xmrwatcher/watcher_test.go
@@ -26,7 +26,10 @@ func TestWatcherDebugDeposit(t *testing.T) {
 	wallet := models.Wallet{ClientID: client.ID, AssetID: asset.ID, Value: "subaddr", DerivationIndex: 2}
 	db.Create(&wallet)
 
-	w := New(db, "", time.Second, true)
+	w, err := New(db, "", time.Second, true)
+	if err != nil {
+		t.Fatalf("watcher: %v", err)
+	}
 	w.Start()
 	w.TriggerDeposit(wallet.ID, decimal.RequireFromString("4"))
 	time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
## Изменения
- расширена конфигурация приложения параметрами RPC для BTC, ETH и Monero
- наблюдатели используют URL и учётные данные из конфигурации
- обновлены README и `.env.example`

## Тесты
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f4f63a0808332bcda6a7a3d84fee4