### PR TITLE
Добавлен посев активов и основных валют

### DIFF
--- a/internal/db/seed.go
+++ b/internal/db/seed.go
@@ -50,8 +50,18 @@ func SeedAssets(db *gorm.DB) error {
 		return nil
 	}
 	assets := []models.Asset{
+		// fiat
 		{Name: "USD", Type: models.AssetTypeFiat, IsConvertible: true, IsActive: true},
+		{Name: "EUR", Type: models.AssetTypeFiat, IsConvertible: true, IsActive: true},
+		{Name: "UAH", Type: models.AssetTypeFiat, IsConvertible: true, IsActive: true},
+		{Name: "GBP", Type: models.AssetTypeFiat, IsConvertible: true, IsActive: true},
+		{Name: "PLN", Type: models.AssetTypeFiat, IsConvertible: true, IsActive: true},
+		// crypto
 		{Name: "BTC", Type: models.AssetTypeCrypto, IsActive: true},
+		{Name: "ETH", Type: models.AssetTypeCrypto, IsActive: true},
+		{Name: "USDT", Type: models.AssetTypeCrypto, IsActive: true},
+		{Name: "USDC", Type: models.AssetTypeCrypto, IsActive: true},
+		{Name: "XMR", Type: models.AssetTypeCrypto, IsActive: true},
 	}
 	return db.Create(&assets).Error
 }

--- a/internal/db/seed_test.go
+++ b/internal/db/seed_test.go
@@ -55,8 +55,22 @@ func TestSeedPaymentMethodsAndAssets(t *testing.T) {
 	var pmCount, assetCount int64
 	gdb.Model(&models.PaymentMethod{}).Count(&pmCount)
 	gdb.Model(&models.Asset{}).Count(&assetCount)
-	if pmCount != 2 || assetCount != 2 {
-		t.Fatalf("expected 2 methods and 2 assets, got %d and %d", pmCount, assetCount)
+	if pmCount != 2 || assetCount != 10 {
+		t.Fatalf("expected 2 methods and 10 assets, got %d and %d", pmCount, assetCount)
+	}
+	var assets []models.Asset
+	if err := gdb.Find(&assets).Error; err != nil {
+		t.Fatalf("list assets: %v", err)
+	}
+	want := []string{"USD", "EUR", "UAH", "GBP", "PLN", "BTC", "ETH", "USDT", "USDC", "XMR"}
+	names := make(map[string]bool)
+	for _, a := range assets {
+		names[a.Name] = true
+	}
+	for _, n := range want {
+		if !names[n] {
+			t.Fatalf("missing asset %s", n)
+		}
 	}
 	if err := SeedPaymentMethods(gdb); err != nil {
 		t.Fatalf("reseeding methods: %v", err)


### PR DESCRIPTION
## Описание
- расширен посев базовых активов криптовалютами BTC, ETH, USDT, USDC и XMR
- добавлены активные фиатные валюты USD, EUR, UAH, GBP и PLN
- обновлены тесты посева активов

## Тестирование
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f507e0ec08332b1959cd439cf3224