### PR TITLE
feat: link payment methods to countries

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1661,6 +1661,12 @@ const docTemplate = `{
                 "provider": {
                     "type": "string"
                 },
+                "countries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Country"
+                    }
+                },
                 "regions": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1654,6 +1654,12 @@
                 "provider": {
                     "type": "string"
                 },
+                "countries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Country"
+                    }
+                },
                 "regions": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -344,6 +344,10 @@ definitions:
         type: string
       provider:
         type: string
+      countries:
+        items:
+          $ref: '#/definitions/models.Country'
+        type: array
       regions:
         items:
           type: string

--- a/internal/models/payment_method.go
+++ b/internal/models/payment_method.go
@@ -38,12 +38,13 @@ func (KycLevelHintType) GormDBDataType(db *gorm.DB, field *schema.Field) string 
 }
 
 type PaymentMethod struct {
-	ID                    string   `gorm:"primaryKey;size:21"`
-	Name                  string   `gorm:"type:varchar(255);unique;not null"`
-	MethodGroup           string   `gorm:"type:varchar(100)"`
-	Provider              string   `gorm:"type:varchar(100)"`
-	TypicalFiatCCY        string   `gorm:"type:varchar(10)"`
-	Regions               []string `gorm:"type:json;serializer:json"`
+	ID                    string    `gorm:"primaryKey;size:21"`
+	Name                  string    `gorm:"type:varchar(255);unique;not null"`
+	MethodGroup           string    `gorm:"type:varchar(100)"`
+	Provider              string    `gorm:"type:varchar(100)"`
+	TypicalFiatCCY        string    `gorm:"type:varchar(10)"`
+	Regions               []string  `gorm:"type:json;serializer:json"`
+	Countries             []Country `gorm:"many2many:payment_method_countries"`
 	IsRealtime            bool
 	IsReversible          bool
 	SettlementMinutes     uint


### PR DESCRIPTION
## Summary
- add many-to-many relationship between payment methods and countries
- seed payment methods with linked countries
- document new `countries` field in Swagger

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f5879103c8332b626209af99ebd4b