### PR TITLE
feat: add order chat and message models

### DIFF
--- a/internal/models/order_chat.go
+++ b/internal/models/order_chat.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type OrderChat struct {
+	ID        string    `gorm:"primaryKey;size:21"`
+	OrderID   string    `gorm:"size:21;not null;uniqueIndex"`
+	Order     Order     `gorm:"foreignKey:OrderID" json:"-"`
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+}
+
+func (c *OrderChat) BeforeCreate(tx *gorm.DB) (err error) {
+	if c.ID == "" {
+		c.ID, err = utils.GenerateNanoID()
+	}
+	return
+}

--- a/internal/models/order_message.go
+++ b/internal/models/order_message.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+type MessageType string
+
+const (
+	MessageTypeText   MessageType = "TEXT"
+	MessageTypeSystem MessageType = "SYSTEM"
+	MessageTypeFile   MessageType = "FILE"
+)
+
+type OrderMessage struct {
+	ID        string      `gorm:"primaryKey;size:21"`
+	ChatID    string      `gorm:"size:21;not null;index"`
+	Chat      OrderChat   `gorm:"foreignKey:ChatID" json:"-"`
+	ClientID  string      `gorm:"size:21;not null;index"`
+	Client    Client      `gorm:"foreignKey:ClientID" json:"-"`
+	Type      MessageType `gorm:"type:varchar(10);not null"`
+	Content   string      `gorm:"type:text;not null"`
+	CreatedAt time.Time   `gorm:"autoCreateTime;index"`
+	UpdatedAt time.Time   `gorm:"autoUpdateTime"`
+}
+
+func (m *OrderMessage) BeforeCreate(tx *gorm.DB) (err error) {
+	if m.ID == "" {
+		m.ID, err = utils.GenerateNanoID()
+	}
+	return
+}


### PR DESCRIPTION
## Summary
- add OrderChat model with unique order link and nanoid generation
- add OrderMessage model with message type enum and nanoid generation

## Testing
- `go test ./internal/models -run TestNonExistent`


------
https://chatgpt.com/codex/tasks/task_e_688f5d7d8d9c83328c2ecca300132764