### PR TITLE
feat: add order message handlers

### DIFF
--- a/internal/handlers/order_message.go
+++ b/internal/handlers/order_message.go
@@ -1,0 +1,194 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// OrderMessageRequest используется для текстовых сообщений.
+type OrderMessageRequest struct {
+	Content string `json:"content"`
+}
+
+// ListOrderMessages godoc
+// @Summary Список сообщений ордера
+// @Tags orders
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "ID ордера"
+// @Param cursor query string false "cursor"
+// @Param after query string false "after"
+// @Success 200 {array} models.OrderMessage
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /orders/{id}/messages [get]
+func ListOrderMessages(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		orderID := c.Param("id")
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var order models.Order
+		if err := db.Where("id = ?", orderID).First(&order).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid order"})
+			return
+		}
+		if clientID != order.BuyerID && clientID != order.SellerID {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: "forbidden"})
+			return
+		}
+		var chat models.OrderChat
+		if err := db.Where("order_id = ?", order.ID).First(&chat).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusOK, []models.OrderMessage{})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		q := db.Where("chat_id = ?", chat.ID)
+		if cursor := c.Query("cursor"); cursor != "" {
+			q = q.Where("id > ?", cursor)
+		}
+		if after := c.Query("after"); after != "" {
+			if t, err := time.Parse(time.RFC3339, after); err == nil {
+				q = q.Where("created_at > ?", t)
+			}
+		}
+		var msgs []models.OrderMessage
+		if err := q.Order("created_at asc").Limit(50).Find(&msgs).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, msgs)
+	}
+}
+
+// CreateOrderMessage godoc
+// @Summary Отправить сообщение в ордер
+// @Tags orders
+// @Security BearerAuth
+// @Accept json
+// @Accept multipart/form-data
+// @Produce json
+// @Param id path string true "ID ордера"
+// @Param input body OrderMessageRequest false "данные"
+// @Param file formData file false "файл"
+// @Success 200 {object} models.OrderMessage
+// @Failure 400 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /orders/{id}/messages [post]
+func CreateOrderMessage(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		orderID := c.Param("id")
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var order models.Order
+		if err := db.Where("id = ?", orderID).First(&order).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid order"})
+			return
+		}
+		if clientID != order.BuyerID && clientID != order.SellerID {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: "forbidden"})
+			return
+		}
+		var chat models.OrderChat
+		if err := db.Where("order_id = ?", order.ID).First(&chat).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				chat = models.OrderChat{OrderID: order.ID}
+				if err := db.Create(&chat).Error; err != nil {
+					c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+					return
+				}
+			} else {
+				c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+				return
+			}
+		}
+		var msg models.OrderMessage
+		if c.ContentType() == "multipart/form-data" {
+			file, err := c.FormFile("file")
+			if err != nil {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid file"})
+				return
+			}
+			msg = models.OrderMessage{ChatID: chat.ID, ClientID: clientID, Type: models.MessageTypeFile, Content: file.Filename}
+		} else {
+			var r OrderMessageRequest
+			if err := c.BindJSON(&r); err != nil || r.Content == "" {
+				c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid json"})
+				return
+			}
+			msg = models.OrderMessage{ChatID: chat.ID, ClientID: clientID, Type: models.MessageTypeText, Content: r.Content}
+		}
+		if err := db.Create(&msg).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, msg)
+	}
+}
+
+// ReadOrderMessage godoc
+// @Summary Отметить сообщение прочитанным
+// @Tags orders
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "ID ордера"
+// @Param msgId path string true "ID сообщения"
+// @Success 200 {object} models.OrderMessage
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /orders/{id}/messages/{msgId}/read [patch]
+func ReadOrderMessage(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		orderID := c.Param("id")
+		msgID := c.Param("msgId")
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var order models.Order
+		if err := db.Where("id = ?", orderID).First(&order).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid order"})
+			return
+		}
+		if clientID != order.BuyerID && clientID != order.SellerID {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: "forbidden"})
+			return
+		}
+		var chat models.OrderChat
+		if err := db.Where("order_id = ?", order.ID).First(&chat).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid message"})
+			return
+		}
+		var msg models.OrderMessage
+		if err := db.Where("id = ? AND chat_id = ?", msgID, chat.ID).First(&msg).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid message"})
+			return
+		}
+		now := time.Now()
+		if err := db.Model(&msg).Update("read_at", now).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		msg.ReadAt = &now
+		c.JSON(http.StatusOK, msg)
+	}
+}

--- a/internal/handlers/order_message_test.go
+++ b/internal/handlers/order_message_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"ptop/internal/models"
+)
+
+func TestOrderMessageHandler(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	// register seller
+	body := `{"username":"seller","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"seller","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("seller login status %d", w.Code)
+	}
+	var sellerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &sellerTok)
+	var seller models.Client
+	db.Where("username = ?", "seller").First(&seller)
+
+	// register buyer
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer login status %d", w.Code)
+	}
+	var buyerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &buyerTok)
+	var buyer models.Client
+	db.Where("username = ?", "buyer").First(&buyer)
+
+	// register hacker
+	w = httptest.NewRecorder()
+	body = `{"username":"hacker","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"hacker","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hacker login status %d", w.Code)
+	}
+	var hackerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &hackerTok)
+
+	asset1 := models.Asset{Name: "USD_msg", Type: models.AssetTypeFiat, IsActive: true}
+	asset2 := models.Asset{Name: "BTC_msg", Type: models.AssetTypeCrypto, IsActive: true}
+	if err := db.Create(&asset1).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	if err := db.Create(&asset2).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	offer := models.Offer{
+		MaxAmount:              decimal.RequireFromString("100"),
+		MinAmount:              decimal.RequireFromString("1"),
+		Amount:                 decimal.RequireFromString("50"),
+		Price:                  decimal.RequireFromString("0.1"),
+		FromAssetID:            asset1.ID,
+		ToAssetID:              asset2.ID,
+		OrderExpirationTimeout: 10,
+		TTL:                    time.Now().Add(24 * time.Hour),
+		ClientID:               seller.ID,
+	}
+	if err := db.Create(&offer).Error; err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("order status %d", w.Code)
+	}
+	var ord models.Order
+	json.Unmarshal(w.Body.Bytes(), &ord)
+
+	// buyer sends message
+	w = httptest.NewRecorder()
+	body = `{"content":"hello"}`
+	req, _ = http.NewRequest("POST", "/orders/"+ord.ID+"/messages", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create message status %d", w.Code)
+	}
+	var msg models.OrderMessage
+	json.Unmarshal(w.Body.Bytes(), &msg)
+
+	// hacker tries to get messages
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/orders/"+ord.ID+"/messages", nil)
+	req.Header.Set("Authorization", "Bearer "+hackerTok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden, got %d", w.Code)
+	}
+
+	// buyer lists messages
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/orders/"+ord.ID+"/messages", nil)
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list messages status %d", w.Code)
+	}
+	var list []models.OrderMessage
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(list))
+	}
+
+	// seller marks message read
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PATCH", "/orders/"+ord.ID+"/messages/"+msg.ID+"/read", nil)
+	req.Header.Set("Authorization", "Bearer "+sellerTok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("read status %d", w.Code)
+	}
+	var upd models.OrderMessage
+	json.Unmarshal(w.Body.Bytes(), &upd)
+	if upd.ReadAt == nil {
+		t.Fatalf("expected read at not nil")
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -34,6 +34,8 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 		&models.Balance{},
 		&models.Escrow{},
 		&models.Order{},
+		&models.OrderChat{},
+		&models.OrderMessage{},
 		&models.TransactionIn{},
 		&models.TransactionOut{},
 		&models.TransactionInternal{},
@@ -71,6 +73,9 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	api.GET("/client/escrows", ListClientEscrows(db))
 	api.GET("/client/orders", ListClientOrders(db))
 	api.POST("/client/orders", CreateOrder(db))
+	api.GET("/orders/:id/messages", ListOrderMessages(db))
+	api.POST("/orders/:id/messages", CreateOrderMessage(db))
+	api.PATCH("/orders/:id/messages/:msgId/read", ReadOrderMessage(db))
 
 	maxOffers := 1
 	api.GET("/offers", ListOffers(db))

--- a/internal/models/order_message.go
+++ b/internal/models/order_message.go
@@ -23,6 +23,7 @@ type OrderMessage struct {
 	Client    Client      `gorm:"foreignKey:ClientID" json:"-"`
 	Type      MessageType `gorm:"type:varchar(10);not null"`
 	Content   string      `gorm:"type:text;not null"`
+	ReadAt    *time.Time  `gorm:"index"`
 	CreatedAt time.Time   `gorm:"autoCreateTime;index"`
 	UpdatedAt time.Time   `gorm:"autoUpdateTime"`
 }


### PR DESCRIPTION
## Summary
- add handlers for listing, sending and reading order messages
- persist message read timestamp
- cover order messaging with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f619628a083328bb9d0540c49843f