### PR TITLE
test: cover chat cache and ws docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ REDIS_ADDR=127.0.0.1:6379
 REDIS_PASSWORD=
 REDIS_DB=0
 
+# количество сообщений, сохраняемых в кеш чата
+CHAT_CACHE_LIMIT=50
+
 # любые другие настройки
 # JWT_SECRET=supersecretkey
 # TIMEZONE=Europe/Warsaw

--- a/README.md
+++ b/README.md
@@ -13,4 +13,26 @@ Rest api на golang, gin, postgresql, GORN ORM.
 | `BTC_RPC_PASS` | пароль Bitcoin RPC |
 | `ETH_RPC_URL` | URL Ethereum RPC |
 | `MONERO_RPC_URL` | URL Monero RPC |
+| `REDIS_ADDR` | адрес сервера Redis |
+| `REDIS_PASSWORD` | пароль Redis (если требуется) |
+| `REDIS_DB` | номер базы Redis |
+| `CHAT_CACHE_LIMIT` | количество сообщений истории в кешe |
+
+## WebSocket чат ордера
+
+Подписка на обновления сообщений осуществляется через WebSocket:
+
+```
+wss://<host>/ws/orders/{orderID}/chat
+```
+
+Перед подключением клиент должен получить `access_token` и передать его в заголовке `Authorization: Bearer <token>`.
+
+После подключения сервер отправит историю последних сообщений из кеша Redis. Чтобы отправить новое сообщение, нужно послать JSON:
+
+```json
+{ "content": "текст сообщения" }
+```
+
+Каждое отправленное сообщение будет сохранено в БД и рассылается всем подключённым участникам ордера.
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	rdb := redis.NewClient(&redis.Options{Addr: cfg.RedisAddr, Password: cfg.RedisPassword, DB: cfg.RedisDB})
-	chatCache := services.NewChatCache(rdb, 50)
+	chatCache := services.NewChatCache(rdb, cfg.ChatCacheLimit)
 
 	docs.SwaggerInfo.BasePath = "/"
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	RedisAddr                string
 	RedisPassword            string
 	RedisDB                  int
+	ChatCacheLimit           int64
 	// Другие поля, например:
 	// JWTSecret string
 	// Timezone  string
@@ -70,6 +71,11 @@ func Load() (*Config, error) {
 		redisDB = v
 	}
 
+	chatLimit := int64(50)
+	if v, err := strconv.ParseInt(os.Getenv("CHAT_CACHE_LIMIT"), 10, 64); err == nil {
+		chatLimit = v
+	}
+
 	return &Config{
 		Port: port,
 		DSN:  dsn,
@@ -87,6 +93,7 @@ func Load() (*Config, error) {
 		RedisAddr:                redisAddr,
 		RedisPassword:            redisPass,
 		RedisDB:                  redisDB,
+		ChatCacheLimit:           chatLimit,
 		// JWTSecret: os.Getenv("JWT_SECRET"),
 		// Timezone:  os.Getenv("TIMEZONE"),
 	}, nil

--- a/internal/services/chat_cache_test.go
+++ b/internal/services/chat_cache_test.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"ptop/internal/models"
+)
+
+func TestChatCache(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	cache := NewChatCache(rdb, 3)
+
+	ctx := context.Background()
+	for i := 1; i <= 4; i++ {
+		msg := models.OrderMessage{ID: fmt.Sprintf("m%d", i), Content: fmt.Sprintf("%d", i)}
+		if err := cache.AddMessage(ctx, "chat1", msg); err != nil {
+			t.Fatalf("add %d: %v", i, err)
+		}
+	}
+
+	history, err := cache.GetHistory(ctx, "chat1")
+	if err != nil {
+		t.Fatalf("get history: %v", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(history))
+	}
+	for idx, want := range []string{"m2", "m3", "m4"} {
+		if history[idx].ID != want {
+			t.Fatalf("want id %s at %d, got %s", want, idx, history[idx].ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `CHAT_CACHE_LIMIT` to config and sample env
- document websocket chat usage in README
- cover chat cache service with tests

## Testing
- `go test ./internal/services -run TestChatCache -count=1`
- `go test ./internal/handlers -count=1`
- `go test ./...` *(fails: TestSeedPaymentMethodsAndAssets)*

------
https://chatgpt.com/codex/tasks/task_e_688f5b8c7a5883328c7b3e41c208d3be