### PR TITLE
Добавлены настройки S3 и документация по MinIO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,14 @@ REDIS_DB=0
 # количество сообщений, сохраняемых в кеш чата
 CHAT_CACHE_LIMIT=50
 
+# параметры S3/MinIO
+S3_ENDPOINT=127.0.0.1:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=ptop
+S3_REGION=us-east-1
+S3_USE_SSL=false
+
 # любые другие настройки
 # JWT_SECRET=supersecretkey
 # TIMEZONE=Europe/Warsaw

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Rest api на golang, gin, postgresql, GORN ORM.
 | `REDIS_PASSWORD` | пароль Redis (если требуется) |
 | `REDIS_DB` | номер базы Redis |
 | `CHAT_CACHE_LIMIT` | количество сообщений истории в кешe |
+| `S3_ENDPOINT` | адрес S3/MinIO |
+| `S3_ACCESS_KEY` | ключ доступа S3/MinIO |
+| `S3_SECRET_KEY` | секретный ключ S3/MinIO |
+| `S3_BUCKET` | имя бакета |
+| `S3_REGION` | регион S3 |
+| `S3_USE_SSL` | использовать HTTPS при подключении |
 
 ## WebSocket чат ордера
 
@@ -35,4 +41,57 @@ wss://<host>/ws/orders/{orderID}/chat
 ```
 
 Каждое отправленное сообщение будет сохранено в БД и рассылается всем подключённым участникам ордера.
+
+## MinIO для хранения файлов
+
+### Запуск
+
+Простейший способ поднять MinIO локально — через `docker-compose`:
+
+```yaml
+version: '3.7'
+services:
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+```
+
+Запускаем:
+
+```bash
+docker-compose up -d
+```
+
+### Настройка переменных окружения
+
+В `.env` указываем параметры доступа:
+
+```env
+S3_ENDPOINT=127.0.0.1:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=ptop
+S3_REGION=us-east-1
+S3_USE_SSL=false
+```
+
+### Пример загрузки и получения URL
+
+```go
+svc, _ := storage.New(cfg.S3Endpoint, cfg.S3AccessKey, cfg.S3SecretKey, cfg.S3Bucket, cfg.S3UseSSL)
+f, _ := os.Open("example.png")
+defer f.Close()
+info, _ := f.Stat()
+svc.Upload(context.Background(), "example.png", f, info.Size(), "image/png")
+url, _ := svc.GetURL(context.Background(), "example.png", time.Hour)
+fmt.Println(url)
+```
+
+Файл будет загружен в MinIO, а `url` будет содержать временную ссылку для скачивания.
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -25,6 +26,12 @@ type Config struct {
 	RedisPassword            string
 	RedisDB                  int
 	ChatCacheLimit           int64
+	S3Endpoint               string
+	S3AccessKey              string
+	S3SecretKey              string
+	S3Bucket                 string
+	S3Region                 string
+	S3UseSSL                 bool
 	// Другие поля, например:
 	// JWTSecret string
 	// Timezone  string
@@ -61,6 +68,13 @@ func Load() (*Config, error) {
 	ethURL := os.Getenv("ETH_RPC_URL")
 	moneroURL := os.Getenv("MONERO_RPC_URL")
 
+	s3Endpoint := os.Getenv("S3_ENDPOINT")
+	s3Access := os.Getenv("S3_ACCESS_KEY")
+	s3Secret := os.Getenv("S3_SECRET_KEY")
+	s3Bucket := os.Getenv("S3_BUCKET")
+	s3Region := os.Getenv("S3_REGION")
+	s3UseSSL := os.Getenv("S3_USE_SSL") == "1" || strings.ToLower(os.Getenv("S3_USE_SSL")) == "true"
+
 	redisAddr := os.Getenv("REDIS_ADDR")
 	if redisAddr == "" {
 		redisAddr = "localhost:6379"
@@ -94,6 +108,12 @@ func Load() (*Config, error) {
 		RedisPassword:            redisPass,
 		RedisDB:                  redisDB,
 		ChatCacheLimit:           chatLimit,
+		S3Endpoint:               s3Endpoint,
+		S3AccessKey:              s3Access,
+		S3SecretKey:              s3Secret,
+		S3Bucket:                 s3Bucket,
+		S3Region:                 s3Region,
+		S3UseSSL:                 s3UseSSL,
 		// JWTSecret: os.Getenv("JWT_SECRET"),
 		// Timezone:  os.Getenv("TIMEZONE"),
 	}, nil


### PR DESCRIPTION
## Summary
- расширена структура конфигурации и чтение S3/MinIO настроек
- добавлен пример переменных окружения для локального MinIO
- описан запуск MinIO и пример работы со стореджем

## Testing
- `go test ./...` *(fail: method TIPS (pan-EU rail) expected 0 countries, got 30)*

------
https://chatgpt.com/codex/tasks/task_e_688f837756348332adc58873f2930caa