### PR TITLE
Расширение поля TypicalFiatCCY и корректировка тестов

### DIFF
--- a/internal/models/payment_method.go
+++ b/internal/models/payment_method.go
@@ -44,7 +44,7 @@ type PaymentMethod struct {
 	Name                  string    `gorm:"type:varchar(255);unique;not null"`
 	MethodGroup           string    `gorm:"type:varchar(100)"`
 	Provider              string    `gorm:"type:varchar(100)"`
-	TypicalFiatCCY        string    `gorm:"type:varchar(10)"`
+	TypicalFiatCCY        string    `gorm:"type:varchar(32)"`
 	Regions               []string  `gorm:"type:json;serializer:json"`
 	Countries             []Country `gorm:"many2many:payment_method_countries"`
 	IsRealtime            bool


### PR DESCRIPTION
## Summary
- увеличить длину поля `TypicalFiatCCY` для платёжных методов
- доработать тесты посевов для проверки регионов и валют

## Testing
- `go test ./...`
- `make seed` *(ошибка подключения к Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_688f862f9b788332b71254d0cba1970c