### PR TITLE
feat: обновить 2FA и PIN API

### DIFF
--- a/web/src/api/pin.test.ts
+++ b/web/src/api/pin.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setPinCode } from "./pin";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(global, "localStorage", { value: localStorageMock });
+
+const mockFetch = vi.spyOn(global, "fetch" as any);
+
+describe("pin api", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+  });
+
+  it("setPinCode отправляет пароль и пинкод", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "ok" }),
+    } as any);
+
+    const res = await setPinCode("pass", "1234");
+    expect(mockFetch.mock.calls[0][0]).toContain("/auth/pincode");
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ password: "pass", pincode: "1234" }),
+    });
+    expect(res).toEqual({ status: "ok" });
+  });
+});
+

--- a/web/src/api/pin.ts
+++ b/web/src/api/pin.ts
@@ -1,9 +1,9 @@
 import { apiRequest } from './client';
 
 export async function setPinCode(password: string, pinCode: string) {
-  return apiRequest<{ status: string }>('/pin-code/set', {
+  return apiRequest<{ status: string }>('/auth/pincode', {
     method: 'POST',
-    body: JSON.stringify({ password, pin_code: pinCode }),
+    body: JSON.stringify({ password, pincode: pinCode }),
   });
 }
 

--- a/web/src/api/two_factor.test.ts
+++ b/web/src/api/two_factor.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { enable2fa } from "./two_factor";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(global, "localStorage", { value: localStorageMock });
+
+const mockFetch = vi.spyOn(global, "fetch" as any);
+
+describe("two_factor api", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+  });
+
+  it("enable2fa отправляет пароль и получает секрет", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ secret: "sec", url: "otp" }),
+    } as any);
+
+    const res = await enable2fa("pass");
+    expect(mockFetch.mock.calls[0][0]).toContain("/auth/2fa/enable");
+    expect(mockFetch.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ password: "pass" }),
+    });
+    expect(res).toEqual({ secret: "sec", url: "otp" });
+  });
+});
+

--- a/web/src/api/two_factor.ts
+++ b/web/src/api/two_factor.ts
@@ -2,29 +2,13 @@ import { apiRequest } from './client';
 
 interface EnableResponse {
   secret: string;
-  otpauth_url: string;
+  url: string;
 }
 
-interface VerifyResponse {
-  verified: boolean;
-}
-
-export async function enable2fa() {
-  return apiRequest<EnableResponse>('/2fa/enable', {
-    method: 'POST',
-  });
-}
-
-export async function verify2fa(code: string) {
-  return apiRequest<VerifyResponse>('/2fa/verify', {
-    method: 'POST',
-    body: JSON.stringify({ code }),
-  });
-}
-
-export async function disable2fa(password: string) {
-  return apiRequest<{ status: string }>('/2fa/disable', {
+export async function enable2fa(password: string) {
+  return apiRequest<EnableResponse>('/auth/2fa/enable', {
     method: 'POST',
     body: JSON.stringify({ password }),
   });
 }
+

--- a/web/src/context/AuthContext.test.tsx
+++ b/web/src/context/AuthContext.test.tsx
@@ -17,7 +17,6 @@ vi.mock("@/api/auth", () => ({
   profile: vi.fn(),
 }));
 vi.mock("@/api/pin", () => ({ setPinCode: vi.fn() }));
-vi.mock("@/api/two_factor", () => ({ disable2fa: vi.fn() }));
 
 describe("AuthContext", () => {
   beforeEach(() => {

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -11,7 +11,6 @@ import {
   type MnemonicResponse,
 } from "@/api/auth";
 import { setPinCode as apiSetPinCode } from "@/api/pin";
-import { disable2fa as apiDisable2fa } from "@/api/two_factor";
 import {
   loadTokens,
   saveTokens,
@@ -46,7 +45,6 @@ interface AuthContextValue {
   ) => Promise<void>;
   regenerateWords: (password: string) => Promise<MnemonicResponse>;
   changePassword: (current: string, newPwd: string) => Promise<void>;
-  disable2fa: (password: string) => Promise<void>;
   setPinCode: (password: string, pin: string) => Promise<void>;
 }
 
@@ -162,11 +160,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     await apiChangePassword(current, newPwd);
   };
 
-  const disable2fa = async (password: string): Promise<void> => {
-    await apiDisable2fa(password);
-    // optionally refresh state
-  };
-
   const setPinCode = async (
     password: string,
     pin: string,
@@ -187,7 +180,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         recover,
         regenerateWords,
         changePassword,
-        disable2fa,
         setPinCode,
       }}
     >


### PR DESCRIPTION
## Summary
- update PIN endpoint and field
- streamline 2FA enable flow and remove verification/disable
- drop disable2fa from auth context and add tests

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components...)*

------
https://chatgpt.com/codex/tasks/task_e_688f940477588332b6e37e0921cafe18