### PR TITLE
fix: изменить путь смены пароля

### DIFF
--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -7,6 +7,7 @@ import {
   refresh,
   profile,
   recoverChallenge,
+  changePassword,
 } from "./auth";
 
 const localStorageMock = (() => {
@@ -109,6 +110,26 @@ describe("auth api", () => {
     const res = await recoverChallenge("user");
     expect(mockFetch).toHaveBeenCalled();
     expect(res).toEqual({ positions: [1, 2, 3] });
+  });
+
+  it("changePassword отправляет корректный payload", async () => {
+    const mockFetch = vi
+      .spyOn(global, "fetch" as any)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "ok" }),
+      } as any);
+
+    await changePassword("old", "new");
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect((url as string).endsWith("/auth/password")).toBe(true);
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({
+      old_password: "old",
+      new_password: "new",
+      confirm_password: "new",
+    });
   });
 
   it("refresh использует refresh_token", async () => {

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -82,12 +82,17 @@ export async function regenerateWords(password: string) {
   });
 }
 
-export async function changePassword(currentPassword: string, newPassword: string) {
-  return apiRequest<
-    { status: string }
-  >("/auth/change-password", {
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+) {
+  return apiRequest<{ status: string }>("/auth/password", {
     method: "POST",
-    body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+    body: JSON.stringify({
+      old_password: currentPassword,
+      new_password: newPassword,
+      confirm_password: newPassword,
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
- use new `/auth/password` endpoint for password changes
- cover changePassword request with tests

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Fast refresh only works..., Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_688fb0223fec8332bca2223535efb278