### PR TITLE
feat: verify password endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -78,6 +78,7 @@ func main() {
 	auth.POST("/username", handlers.ChangeUsername(gormDB))
 	auth.POST("/pincode", handlers.SetPinCode(gormDB))
 	auth.POST("/2fa/enable", handlers.Enable2FA(gormDB))
+	auth.POST("/verify-password", handlers.VerifyPassword(gormDB))
 	auth.POST("/password", handlers.ChangePassword(gormDB))
 
 	api := r.Group("/")

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -479,6 +479,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/verify-password": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Проверка текущего пароля",
+                "parameters": [
+                    {
+                        "description": "пароль",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/client/balances": {
             "get": {
                 "security": [
@@ -1649,6 +1699,22 @@ const docTemplate = `{
                 },
                 "refresh_token": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.VerifyPasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.VerifyPasswordResponse": {
+            "type": "object",
+            "properties": {
+                "verified": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -472,6 +472,56 @@
                 }
             }
         },
+        "/auth/verify-password": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Проверка текущего пароля",
+                "parameters": [
+                    {
+                        "description": "пароль",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/client/balances": {
             "get": {
                 "security": [
@@ -1642,6 +1692,22 @@
                 },
                 "refresh_token": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.VerifyPasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.VerifyPasswordResponse": {
+            "type": "object",
+            "properties": {
+                "verified": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -169,6 +169,16 @@ definitions:
       refresh_token:
         type: string
     type: object
+  handlers.VerifyPasswordRequest:
+    properties:
+      password:
+        type: string
+    type: object
+  handlers.VerifyPasswordResponse:
+    properties:
+      verified:
+        type: boolean
+    type: object
   handlers.WalletRequest:
     properties:
       asset_id:
@@ -736,6 +746,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Смена имени пользователя
+      tags:
+      - auth
+  /auth/verify-password:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: пароль
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.VerifyPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.VerifyPasswordResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Проверка текущего пароля
       tags:
       - auth
   /client/balances:

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -81,6 +81,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	auth.POST("/username", ChangeUsername(db))
 	auth.POST("/pincode", SetPinCode(db))
 	auth.POST("/2fa/enable", Enable2FA(db))
+	auth.POST("/verify-password", VerifyPassword(db))
 	auth.POST("/password", ChangePassword(db))
 
 	api := r.Group("/")

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -8,6 +8,7 @@ import {
   profile,
   recoverChallenge,
   changePassword,
+  verifyPassword,
 } from "./auth";
 
 const localStorageMock = (() => {
@@ -130,6 +131,23 @@ describe("auth api", () => {
       new_password: "new",
       confirm_password: "new",
     });
+  });
+
+  it("verifyPassword отправляет пароль и возвращает результат", async () => {
+    const mockFetch = vi
+      .spyOn(global, "fetch" as any)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ verified: true }),
+      } as any);
+
+    const res = await verifyPassword("pwd");
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect((url as string).endsWith("/auth/verify-password")).toBe(true);
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ password: "pwd" });
+    expect(res).toEqual({ verified: true });
   });
 
   it("refresh использует refresh_token", async () => {


### PR DESCRIPTION
## Summary
- проверить текущий пароль через новый эндпоинт `/auth/verify-password`
- добавить документацию и регистрацию маршрута
- протестировать серверный и клиентский код

## Testing
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fd3c7db6c833296765e7f3ddcd80f