### PR TITLE
fix: handle mnemonic word objects in register page

### DIFF
--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -60,7 +60,10 @@ describe("auth api", () => {
         json: async () => ({
           access_token: "a",
           refresh_token: "r",
-          mnemonic: "one two",
+          mnemonic: [
+            { position: 1, word: "one" },
+            { position: 2, word: "two" },
+          ],
         }),
       } as any);
 
@@ -71,7 +74,14 @@ describe("auth api", () => {
       password: "pass",
       password_confirm: "pass",
     });
-    expect(res).toEqual({ access: "a", refresh: "r", mnemonic: "one two" });
+    expect(res).toEqual({
+      access: "a",
+      refresh: "r",
+      mnemonic: [
+        { position: 1, word: "one" },
+        { position: 2, word: "two" },
+      ],
+    });
   });
 
   it("recover отправляет правильный payload", async () => {

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -6,13 +6,19 @@ interface TokenResponse {
   refresh_token: string;
 }
 
-export interface MnemonicResponse {
-  mnemonic: string;
+export interface MnemonicWord {
+  position: number;
+  word: string;
 }
 
-export interface RegisterResponse extends MnemonicResponse {
+export interface RegisterResponse {
   access: string;
   refresh: string;
+  mnemonic: MnemonicWord[];
+}
+
+export interface MnemonicResponse {
+  mnemonic: string;
 }
 
 export async function login(
@@ -32,7 +38,7 @@ export async function register(
   passwordConfirm: string,
 ): Promise<RegisterResponse> {
   const { access_token, refresh_token, mnemonic } = await apiRequest<
-    TokenResponse & { mnemonic: string }
+    TokenResponse & { mnemonic: MnemonicWord[] }
   >("/auth/register", {
     method: "POST",
     body: JSON.stringify({

--- a/web/src/context/AuthContext.test.tsx
+++ b/web/src/context/AuthContext.test.tsx
@@ -64,7 +64,14 @@ describe("AuthContext", () => {
 
   it("register возвращает мнемонику", async () => {
     const { register } = await import("@/api/auth");
-    vi.mocked(register).mockResolvedValue({ access: "a", refresh: "r", mnemonic: "one two" });
+    vi.mocked(register).mockResolvedValue({
+      access: "a",
+      refresh: "r",
+      mnemonic: [
+        { position: 1, word: "one" },
+        { position: 2, word: "two" },
+      ],
+    });
 
     let ctx: ReturnType<typeof useAuth> | undefined;
     const Consumer = () => {
@@ -88,7 +95,14 @@ describe("AuthContext", () => {
     });
 
     expect(register).toHaveBeenCalledWith("u", "p", "p");
-    expect(res).toEqual({ access: "a", refresh: "r", mnemonic: "one two" });
+    expect(res).toEqual({
+      access: "a",
+      refresh: "r",
+      mnemonic: [
+        { position: 1, word: "one" },
+        { position: 2, word: "two" },
+      ],
+    });
   });
 
   it("refresh обновляет токены и userInfo", async () => {

--- a/web/src/pages/Register.test.tsx
+++ b/web/src/pages/Register.test.tsx
@@ -6,7 +6,7 @@ import Register from './Register';
 const registerMock = vi.fn();
 vi.mock('@/context', () => ({ useAuth: () => ({ register: registerMock }) }));
 
-const words = Array.from({ length: 12 }, (_, i) => `w${i + 1}`);
+const words = Array.from({ length: 12 }, (_, i) => ({ position: i + 1, word: `w${i + 1}` }));
 
 // Mock clipboard
 Object.assign(navigator, {

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -33,7 +33,13 @@ const Register = () => {
                 formData.password,
                 formData.confirmPassword,
             );
-            setMnemonic(Array.isArray(mnemonic) ? mnemonic.join(' ') : mnemonic);
+            setMnemonic(
+                Array.isArray(mnemonic)
+                    ? mnemonic
+                        .map((w: any) => (typeof w === 'string' ? w : w.word))
+                        .join(' ')
+                    : mnemonic,
+            );
             toast('Успешная регистрация');
         } catch (err) {
             console.error('Registration error:', err);


### PR DESCRIPTION
## Summary
- support mnemonic word objects from backend
- adjust related tests

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c6f116888332a94262dc466a070a