### PR TITLE
Загрузка фильтров из API

### DIFF
--- a/web/src/api/dictionaries.test.ts
+++ b/web/src/api/dictionaries.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getPaymentMethods } from './dictionaries';
+import { apiRequest } from './client';
+
+vi.mock('./client', () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe('dictionaries api', () => {
+  it('запрашивает методы оплаты без страны', async () => {
+    const apiReqMock = apiRequest as unknown as ReturnType<typeof vi.fn>;
+    apiReqMock.mockResolvedValue([]);
+    await getPaymentMethods();
+    expect(apiRequest).toHaveBeenCalledWith('/payment-methods');
+  });
+
+  it('запрашивает методы оплаты с указанной страной', async () => {
+    const apiReqMock = apiRequest as unknown as ReturnType<typeof vi.fn>;
+    apiReqMock.mockResolvedValue([]);
+    await getPaymentMethods('RU');
+    expect(apiRequest).toHaveBeenCalledWith('/payment-methods?country=RU');
+  });
+});

--- a/web/src/api/dictionaries.ts
+++ b/web/src/api/dictionaries.ts
@@ -12,6 +12,9 @@ export async function getDurations() {
   return apiRequest<any[]>('/durations');
 }
 
-export async function getPaymentMethods(country: string) {
-  return apiRequest<any[]>(`/payment-methods?country=${encodeURIComponent(country)}`);
+export async function getPaymentMethods(country?: string) {
+  const endpoint = country
+    ? `/payment-methods?country=${encodeURIComponent(country)}`
+    : '/payment-methods';
+  return apiRequest<any[]>(endpoint);
 }

--- a/web/src/components/FilterPanel.test.tsx
+++ b/web/src/components/FilterPanel.test.tsx
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@/api/dictionaries', () => ({
+  getAssets: vi.fn().mockResolvedValue([
+    { id: 'BTC', name: 'BTC' },
+    { id: 'ETH', name: 'ETH' },
+  ]),
+  getPaymentMethods: vi.fn().mockResolvedValue([
+    { id: 'pm1', name: 'Сбербанк' },
+    { id: 'pm2', name: 'Тинькофф' },
+  ]),
+}));
+
 import { FilterPanel } from './FilterPanel';
 
 describe('FilterPanel', () => {
@@ -11,7 +23,7 @@ describe('FilterPanel', () => {
     paymentMethod: 'all'
   };
 
-  it('вызывает onFiltersChange при смене актива', () => {
+  it('вызывает onFiltersChange при смене актива', async () => {
     const onFiltersChange = vi.fn();
     render(
       <FilterPanel
@@ -23,7 +35,8 @@ describe('FilterPanel', () => {
       />
     );
 
-    fireEvent.change(screen.getByTestId('from-asset'), {
+    const select = (await screen.findAllByTestId('from-asset'))[0];
+    fireEvent.change(select, {
       target: { value: 'BTC' }
     });
 
@@ -33,7 +46,7 @@ describe('FilterPanel', () => {
     });
   });
 
-  it('переключает тип сделки', () => {
+  it('переключает тип сделки', async () => {
     const onTabChange = vi.fn();
     render(
       <FilterPanel
@@ -45,6 +58,7 @@ describe('FilterPanel', () => {
       />
     );
 
+    await screen.findAllByTestId('from-asset');
     const sellBtn = screen.getAllByTestId('sell-tab').pop();
     if (sellBtn) {
       fireEvent.click(sellBtn);

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -1,4 +1,7 @@
 
+import { useEffect, useState } from 'react';
+import { getAssets, getPaymentMethods } from '@/api/dictionaries';
+
 interface FilterPanelProps {
   filters: {
     fromAsset: string;
@@ -19,23 +22,6 @@ interface FilterPanelProps {
   onCreate: () => void;
 }
 
-const assets = [
-  { value: 'all', label: 'Все' },
-  { value: 'BTC', label: 'BTC' },
-  { value: 'ETH', label: 'ETH' },
-  { value: 'USDT', label: 'USDT' },
-  { value: 'BNB', label: 'BNB' }
-];
-
-const paymentMethods = [
-  { value: 'all', label: 'Все способы' },
-  { value: 'sberbank', label: 'Сбербанк' },
-  { value: 'tinkoff', label: 'Тинькофф' },
-  { value: 'alfa', label: 'Альфа-Банк' },
-  { value: 'qiwi', label: 'QIWI' },
-  { value: 'yandex', label: 'ЮMoney' }
-];
-
 export const FilterPanel = ({
   filters,
   onFiltersChange,
@@ -43,6 +29,40 @@ export const FilterPanel = ({
   onTabChange,
   onCreate
 }: FilterPanelProps) => {
+  const [assets, setAssets] = useState<{ value: string; label: string }[]>([
+    { value: 'all', label: 'Все' }
+  ]);
+  const [paymentMethods, setPaymentMethods] = useState<{
+    value: string;
+    label: string;
+  }[]>([{ value: 'all', label: 'Все способы' }]);
+
+  useEffect(() => {
+    async function loadDictionaries() {
+      try {
+        const a = await getAssets();
+        setAssets((prev) => [
+          prev[0],
+          ...a.map((x: any) => ({
+            value: x.id ?? x.asset_code ?? x.name ?? x,
+            label: x.asset_code ?? x.name ?? x
+          }))
+        ]);
+        const pm = await getPaymentMethods();
+        setPaymentMethods((prev) => [
+          prev[0],
+          ...pm.map((x: any) => ({
+            value: x.id ?? x.name ?? x,
+            label: x.name ?? x
+          }))
+        ]);
+      } catch (err) {
+        console.error('load dictionaries error:', err);
+      }
+    }
+    loadDictionaries();
+  }, []);
+
   return (
     <div className="bg-gray-800 rounded-lg p-4 border border-gray-700 mb-3">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">


### PR DESCRIPTION
## Описание
- Подгружаем список активов и способов оплаты через Go Gin API
- Обновляем `getPaymentMethods` и добавляем тесты для словарей

## Тестирование
- `CI=1 npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6895de5203bc833292a4f9b97af3d32e