### PR TITLE
fix: корректная обработка словарей в FilterPanel

### DIFF
--- a/web/src/components/FilterPanel.test.tsx
+++ b/web/src/components/FilterPanel.test.tsx
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 vi.mock('@/api/dictionaries', () => ({
   getAssets: vi.fn().mockResolvedValue([
-    { id: 'BTC', name: 'BTC' },
-    { id: 'ETH', name: 'ETH' },
+    { ID: 'BTC', Name: 'BTC' },
+    { ID: 'ETH', Name: 'ETH' },
   ]),
   getPaymentMethods: vi.fn().mockResolvedValue([
-    { id: 'pm1', name: 'Сбербанк' },
-    { id: 'pm2', name: 'Тинькофф' },
+    { ID: 'pm1', Name: 'Сбербанк' },
+    { ID: 'pm2', Name: 'Тинькофф' },
   ]),
 }));
 
@@ -43,6 +44,29 @@ describe('FilterPanel', () => {
     expect(onFiltersChange).toHaveBeenCalledWith({
       ...baseFilters,
       fromAsset: 'BTC'
+    });
+  });
+
+  it('вызывает onFiltersChange при смене метода оплаты', async () => {
+    const onFiltersChange = vi.fn();
+    render(
+      <FilterPanel
+        filters={baseFilters}
+        onFiltersChange={onFiltersChange}
+        activeTab="buy"
+        onTabChange={() => {}}
+        onCreate={() => {}}
+      />
+    );
+
+    await screen.findAllByText('Сбербанк');
+    const selects = await screen.findAllByTestId('payment-method');
+    const user = userEvent.setup();
+    await user.selectOptions(selects[selects.length - 1], 'pm1');
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...baseFilters,
+      paymentMethod: 'pm1'
     });
   });
 

--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -2,6 +2,21 @@
 import { useEffect, useState } from 'react';
 import { getAssets, getPaymentMethods } from '@/api/dictionaries';
 
+type AssetItem = {
+  id?: string;
+  ID?: string;
+  asset_code?: string;
+  name?: string;
+  Name?: string;
+};
+
+type PaymentMethodItem = {
+  id?: string;
+  ID?: string;
+  name?: string;
+  Name?: string;
+};
+
 interface FilterPanelProps {
   filters: {
     fromAsset: string;
@@ -43,17 +58,17 @@ export const FilterPanel = ({
         const a = await getAssets();
         setAssets((prev) => [
           prev[0],
-          ...a.map((x: any) => ({
-            value: x.id ?? x.asset_code ?? x.name ?? x,
-            label: x.asset_code ?? x.name ?? x
+          ...a.map((x: AssetItem) => ({
+            value: x.id ?? x.ID ?? x.asset_code ?? x.name ?? x.Name ?? x,
+            label: x.asset_code ?? x.name ?? x.Name ?? x
           }))
         ]);
         const pm = await getPaymentMethods();
         setPaymentMethods((prev) => [
           prev[0],
-          ...pm.map((x: any) => ({
-            value: x.id ?? x.name ?? x,
-            label: x.name ?? x
+          ...pm.map((x: PaymentMethodItem) => ({
+            value: x.id ?? x.ID ?? x.name ?? x.Name ?? x,
+            label: x.name ?? x.Name ?? x
           }))
         ]);
       } catch (err) {


### PR DESCRIPTION
## Summary
- поддержаны ID/Name в фильтре активов и методов оплаты
- добавлены типы и тесты для FilterPanel

## Testing
- `npm test -- --run`
- `npm run lint` *(errors: Unexpected any и др.)*
- `go test ./...` *(terminated: ^C)*

------
https://chatgpt.com/codex/tasks/task_e_68963053595083328b2fd5577d58018d