### PR TITLE
feat: regenerate mnemonic seed phrase

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,6 +84,7 @@ func main() {
 	auth.POST("/2fa/enable", handlers.Enable2FA(gormDB))
 	auth.POST("/2fa/disable", handlers.Disable2FA(gormDB))
 	auth.POST("/verify-password", handlers.VerifyPassword(gormDB))
+	auth.POST("/mnemonic/regenerate", handlers.RegenerateMnemonic(gormDB))
 	auth.POST("/password", handlers.ChangePassword(gormDB))
 
 	api := r.Group("/")

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -218,6 +218,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/mnemonic/regenerate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Перегенерация мнемонической фразы",
+                "parameters": [
+                    {
+                        "description": "пароль",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/password": {
             "post": {
                 "security": [
@@ -1802,6 +1852,25 @@ const docTemplate = `{
             "properties": {
                 "refresh_token": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.RegenerateMnemonicRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RegenerateMnemonicResponse": {
+            "type": "object",
+            "properties": {
+                "mnemonic": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MnemonicWord"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -211,6 +211,56 @@
                 }
             }
         },
+        "/auth/mnemonic/regenerate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Перегенерация мнемонической фразы",
+                "parameters": [
+                    {
+                        "description": "пароль",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/password": {
             "post": {
                 "security": [
@@ -1795,6 +1845,25 @@
             "properties": {
                 "refresh_token": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.RegenerateMnemonicRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.RegenerateMnemonicResponse": {
+            "type": "object",
+            "properties": {
+                "mnemonic": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.MnemonicWord"
+                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -155,6 +155,18 @@ definitions:
       refresh_token:
         type: string
     type: object
+  handlers.RegenerateMnemonicRequest:
+    properties:
+      password:
+        type: string
+    type: object
+  handlers.RegenerateMnemonicResponse:
+    properties:
+      mnemonic:
+        items:
+          $ref: '#/definitions/handlers.MnemonicWord'
+        type: array
+    type: object
   handlers.RegisterRequest:
     properties:
       password:
@@ -605,6 +617,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Выход клиента
+      tags:
+      - auth
+  /auth/mnemonic/regenerate:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: пароль
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.RegenerateMnemonicRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.RegenerateMnemonicResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Перегенерация мнемонической фразы
       tags:
       - auth
   /auth/password:

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -83,6 +83,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	auth.POST("/2fa/enable", Enable2FA(db))
 	auth.POST("/2fa/disable", Disable2FA(db))
 	auth.POST("/verify-password", VerifyPassword(db))
+	auth.POST("/mnemonic/regenerate", RegenerateMnemonic(db))
 	auth.POST("/password", ChangePassword(db))
 
 	api := r.Group("/")


### PR DESCRIPTION
## Summary
- add `/auth/mnemonic/regenerate` endpoint to recreate seed phrase after password verification
- document and test mnemonic regeneration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68976be1d6888332a3b4660a3766e18c