### PR TITLE
Добавлен вывод балансов по каждому активному активу

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -688,7 +688,7 @@ const docTemplate = `{
                 "tags": [
                     "reference"
                 ],
-                "summary": "Список активных активов с адресами кошельков клиента",
+                "summary": "Список активных активов с адресами кошельков и балансами клиента",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1639,6 +1639,9 @@ const docTemplate = `{
         "handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "number"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -681,7 +681,7 @@
                 "tags": [
                     "reference"
                 ],
-                "summary": "Список активных активов с адресами кошельков клиента",
+                "summary": "Список активных активов с адресами кошельков и балансами клиента",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1632,6 +1632,9 @@
         "handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "number"
+                },
                 "id": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2,6 +2,8 @@ basePath: /
 definitions:
   handlers.AssetWithWallet:
     properties:
+      amount:
+        type: number
       id:
         type: string
       isActive:
@@ -937,7 +939,7 @@ paths:
             type: array
       security:
       - BearerAuth: []
-      summary: Список активных активов с адресами кошельков клиента
+      summary: Список активных активов с адресами кошельков и балансами клиента
       tags:
       - reference
   /client/balances:


### PR DESCRIPTION
## Summary
- метод `/client/assets` теперь возвращает баланс клиента по всем активным активам
- обновлены swagger-документация и тесты

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689793189bf8833295fc80b1d9d696e9