### PR TITLE
Добавлено поле type для объявлений

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1642,6 +1642,9 @@ const docTemplate = `{
                 "amount": {
                     "type": "number"
                 },
+                "description": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1658,9 +1661,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
-                    "type": "string"
-                },
- 				"description": {
                     "type": "string"
                 }
             }
@@ -1816,6 +1816,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "to_asset_id": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }
@@ -2013,6 +2016,9 @@ const docTemplate = `{
         "models.Asset": {
             "type": "object",
             "properties": {
+                "description": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2164,6 +2170,9 @@ const docTemplate = `{
         "models.Offer": {
             "type": "object",
             "properties": {
+                "TTL": {
+                    "type": "string"
+                },
                 "amount": {
                     "type": "number"
                 },
@@ -2206,7 +2215,7 @@ const docTemplate = `{
                 "toAssetID": {
                     "type": "string"
                 },
-                "ttl": {
+                "type": {
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2280,8 +2289,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "fileType": {
                     "type": "string"
@@ -2382,9 +2390,6 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
-                "disabledAt": {
-                    "type": "string"
-                },
                 "enabledAt": {
                     "type": "string"
                 },
@@ -2393,9 +2398,6 @@ const docTemplate = `{
                 },
                 "index": {
                     "type": "integer"
-                },
-                "isEnabled": {
-                    "type": "boolean"
                 },
                 "value": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1635,6 +1635,9 @@
                 "amount": {
                     "type": "number"
                 },
+                "description": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1806,6 +1809,9 @@
                     "type": "string"
                 },
                 "to_asset_id": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }
@@ -2003,6 +2009,9 @@
         "models.Asset": {
             "type": "object",
             "properties": {
+                "description": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2154,6 +2163,9 @@
         "models.Offer": {
             "type": "object",
             "properties": {
+                "TTL": {
+                    "type": "string"
+                },
                 "amount": {
                     "type": "number"
                 },
@@ -2196,7 +2208,7 @@
                 "toAssetID": {
                     "type": "string"
                 },
-                "ttl": {
+                "type": {
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2270,8 +2282,7 @@
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "fileType": {
                     "type": "string"
@@ -2372,9 +2383,6 @@
                 "createdAt": {
                     "type": "string"
                 },
-                "disabledAt": {
-                    "type": "string"
-                },
                 "enabledAt": {
                     "type": "string"
                 },
@@ -2383,9 +2391,6 @@
                 },
                 "index": {
                     "type": "integer"
-                },
-                "isEnabled": {
-                    "type": "boolean"
                 },
                 "value": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     properties:
       amount:
         type: number
+      description:
+        type: string
       id:
         type: string
       isActive:
@@ -115,6 +117,8 @@ definitions:
       price:
         type: string
       to_asset_id:
+        type: string
+      type:
         type: string
     type: object
   handlers.OrderMessageRequest:
@@ -240,6 +244,8 @@ definitions:
     type: object
   models.Asset:
     properties:
+      description:
+        type: string
       id:
         type: string
       isActive:
@@ -343,6 +349,8 @@ definitions:
     - MessageTypeFile
   models.Offer:
     properties:
+      TTL:
+        type: string
       amount:
         type: number
       clientID:
@@ -371,7 +379,7 @@ definitions:
         type: number
       toAssetID:
         type: string
-      ttl:
+      type:
         type: string
       updatedAt:
         type: string
@@ -420,7 +428,6 @@ definitions:
       createdAt:
         type: string
       fileSize:
-        format: int64
         type: integer
       fileType:
         type: string
@@ -490,16 +497,12 @@ definitions:
         type: string
       createdAt:
         type: string
-      disabledAt:
-        type: string
       enabledAt:
         type: string
       id:
         type: string
       index:
         type: integer
-      isEnabled:
-        type: boolean
       value:
         type: string
     type: object

--- a/internal/handlers/offer_test.go
+++ b/internal/handlers/offer_test.go
@@ -78,6 +78,7 @@ func TestOfferLifecycle(t *testing.T) {
 		MinAmount:              "10",
 		Amount:                 "50",
 		Price:                  "0.12345678",
+		Type:                   models.OfferTypeBuy,
 		FromAssetID:            asset1.ID,
 		ToAssetID:              asset2.ID,
 		OrderExpirationTimeout: 20,
@@ -298,6 +299,7 @@ func TestListOffersFilters(t *testing.T) {
 		MinAmount:              "10",
 		Amount:                 "50",
 		Price:                  "1",
+		Type:                   models.OfferTypeBuy,
 		FromAssetID:            usd.ID,
 		ToAssetID:              btc.ID,
 		ClientPaymentMethodIDs: []string{cpm1.ID},
@@ -321,6 +323,7 @@ func TestListOffersFilters(t *testing.T) {
 		MinAmount:              "200",
 		Amount:                 "300",
 		Price:                  "1",
+		Type:                   models.OfferTypeSell,
 		FromAssetID:            btc.ID,
 		ToAssetID:              usd.ID,
 		ClientPaymentMethodIDs: []string{cpm2.ID},
@@ -340,7 +343,7 @@ func TestListOffersFilters(t *testing.T) {
 
 	// filter: buy offers with amount range and payment method
 	w = httptest.NewRecorder()
-	url := "/offers?from_asset=" + usd.ID + "&to_asset=" + btc.ID + "&min_amount=20&max_amount=80&payment_method=" + pm1.ID + "&type=buy"
+	url := "/offers?from_asset=" + usd.ID + "&to_asset=" + btc.ID + "&min_amount=20&max_amount=80&payment_method=" + pm1.ID + "&type=" + models.OfferTypeBuy
 	req, _ = http.NewRequest("GET", url, nil)
 	req.Header.Set("Authorization", "Bearer "+tok1.AccessToken)
 	r.ServeHTTP(w, req)

--- a/internal/handlers/reference.go
+++ b/internal/handlers/reference.go
@@ -90,7 +90,7 @@ func GetClientAssets(db *gorm.DB) gin.HandlerFunc {
 			Select("assets.id, assets.name, assets.description, assets.type, assets.is_active, assets.is_convertible, COALESCE(wallets.value, '') AS value, COALESCE(balances.amount, 0) AS amount").
 			Joins("LEFT JOIN wallets ON wallets.asset_id = assets.id AND wallets.client_id = ? AND wallets.is_enabled = ?", clientID, true).
 			Joins("LEFT JOIN balances ON balances.asset_id = assets.id AND balances.client_id = ?", clientID).
-			Where("assets.is_active = ? AND assets.type = ?", true, models.AssetTypeCrypto).
+			Where("assets.is_active = ?", true).
 			Scan(&assets).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return

--- a/internal/models/offer.go
+++ b/internal/models/offer.go
@@ -9,12 +9,18 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	OfferTypeBuy  = "buy"
+	OfferTypeSell = "sell"
+)
+
 type Offer struct {
 	ID                     string                `gorm:"primaryKey;size:21" json:"id"`
 	MaxAmount              decimal.Decimal       `gorm:"type:decimal(32,8);not null" json:"maxAmount"`
 	MinAmount              decimal.Decimal       `gorm:"type:decimal(32,8);not null" json:"minAmount"`
 	Amount                 decimal.Decimal       `gorm:"type:decimal(32,8);not null" json:"amount"`
 	Price                  decimal.Decimal       `gorm:"type:decimal(32,8);not null" json:"price"`
+	Type                   string                `gorm:"size:4;not null" json:"type"`
 	FromAssetID            string                `gorm:"size:21;not null" json:"fromAssetID"`
 	FromAsset              Asset                 `gorm:"foreignKey:FromAssetID" json:"-"`
 	ToAssetID              string                `gorm:"size:21;not null" json:"toAssetID"`


### PR DESCRIPTION
## Summary
- добавить строковое поле `type` для объявлений и фильтрацию списка по нему
- обновить обработчики создания/изменения объявлений и swagger-документацию
- исправить выдачу `/client/assets`, возвращая все активные активы
- вынести значения `buy` и `sell` в константы `OfferTypeBuy` и `OfferTypeSell`

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898939820048332a8fb221f86c40626