### PR TITLE
Тесты и swagger для транзакций клиента

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -30,7 +30,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Asset"
+                                "$ref": "#/definitions/ptop_internal_models.Asset"
                             }
                         }
                     }
@@ -61,7 +61,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.Disable2FARequest"
+                            "$ref": "#/definitions/internal_handlers.Disable2FARequest"
                         }
                     }
                 ],
@@ -69,19 +69,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -111,7 +111,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.Enable2FARequest"
+                            "$ref": "#/definitions/internal_handlers.Enable2FARequest"
                         }
                     }
                 ],
@@ -119,19 +119,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Enable2FAResponse"
+                            "$ref": "#/definitions/internal_handlers.Enable2FAResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -157,7 +157,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.LoginRequest"
+                            "$ref": "#/definitions/internal_handlers.LoginRequest"
                         }
                     }
                 ],
@@ -165,19 +165,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -201,13 +201,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -237,7 +237,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
+                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicRequest"
                         }
                     }
                 ],
@@ -245,19 +245,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
+                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -287,7 +287,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChangePasswordRequest"
+                            "$ref": "#/definitions/internal_handlers.ChangePasswordRequest"
                         }
                     }
                 ],
@@ -295,19 +295,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -337,7 +337,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.SetPinCodeRequest"
+                            "$ref": "#/definitions/internal_handlers.SetPinCodeRequest"
                         }
                     }
                 ],
@@ -345,19 +345,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -381,13 +381,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ProfileResponse"
+                            "$ref": "#/definitions/internal_handlers.ProfileResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -412,7 +412,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RecoverRequest"
+                            "$ref": "#/definitions/internal_handlers.RecoverRequest"
                         }
                     }
                 ],
@@ -420,25 +420,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -466,13 +466,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RecoverChallengeResponse"
+                            "$ref": "#/definitions/internal_handlers.RecoverChallengeResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -497,7 +497,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RefreshRequest"
+                            "$ref": "#/definitions/internal_handlers.RefreshRequest"
                         }
                     }
                 ],
@@ -505,19 +505,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -543,7 +543,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegisterRequest"
+                            "$ref": "#/definitions/internal_handlers.RegisterRequest"
                         }
                     }
                 ],
@@ -551,19 +551,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegisterResponse"
+                            "$ref": "#/definitions/internal_handlers.RegisterResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -593,7 +593,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChangeUsernameRequest"
+                            "$ref": "#/definitions/internal_handlers.ChangeUsernameRequest"
                         }
                     }
                 ],
@@ -601,25 +601,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -649,7 +649,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
+                            "$ref": "#/definitions/internal_handlers.VerifyPasswordRequest"
                         }
                     }
                 ],
@@ -657,19 +657,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
+                            "$ref": "#/definitions/internal_handlers.VerifyPasswordResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -695,7 +695,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.AssetWithWallet"
+                                "$ref": "#/definitions/internal_handlers.AssetWithWallet"
                             }
                         }
                     }
@@ -722,7 +722,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Balance"
+                                "$ref": "#/definitions/ptop_internal_models.Balance"
                             }
                         }
                     }
@@ -749,7 +749,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Escrow"
+                                "$ref": "#/definitions/ptop_internal_models.Escrow"
                             }
                         }
                     }
@@ -784,7 +784,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Offer"
+                                "$ref": "#/definitions/ptop_internal_models.Offer"
                             }
                         }
                     }
@@ -813,7 +813,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OfferRequest"
+                            "$ref": "#/definitions/internal_handlers.OfferRequest"
                         }
                     }
                 ],
@@ -821,13 +821,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -864,7 +864,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OfferRequest"
+                            "$ref": "#/definitions/internal_handlers.OfferRequest"
                         }
                     }
                 ],
@@ -872,19 +872,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -914,13 +914,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -950,19 +950,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -988,7 +988,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Order"
+                                "$ref": "#/definitions/ptop_internal_models.Order"
                             }
                         }
                     }
@@ -1017,7 +1017,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OrderRequest"
+                            "$ref": "#/definitions/internal_handlers.OrderRequest"
                         }
                     }
                 ],
@@ -1025,13 +1025,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Order"
+                            "$ref": "#/definitions/ptop_internal_models.Order"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1057,7 +1057,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClientPaymentMethod"
+                                "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
                             }
                         }
                     }
@@ -1086,7 +1086,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateClientPaymentMethodRequest"
+                            "$ref": "#/definitions/internal_handlers.CreateClientPaymentMethodRequest"
                         }
                     }
                 ],
@@ -1094,19 +1094,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClientPaymentMethod"
+                            "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1136,13 +1136,136 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/in": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список входящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionIn"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/internal": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список внутренних транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionInternal"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/out": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список исходящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionOut"
+                            }
                         }
                     }
                 }
@@ -1168,7 +1291,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Wallet"
+                                "$ref": "#/definitions/ptop_internal_models.Wallet"
                             }
                         }
                     }
@@ -1198,7 +1321,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.WalletRequest"
+                            "$ref": "#/definitions/internal_handlers.WalletRequest"
                         }
                     }
                 ],
@@ -1206,13 +1329,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Wallet"
+                            "$ref": "#/definitions/ptop_internal_models.Wallet"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1238,7 +1361,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Country"
+                                "$ref": "#/definitions/ptop_internal_models.Country"
                             }
                         }
                     }
@@ -1265,7 +1388,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.DebugDepositRequest"
+                            "$ref": "#/definitions/internal_handlers.DebugDepositRequest"
                         }
                     }
                 ],
@@ -1307,13 +1430,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1377,7 +1500,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Offer"
+                                "$ref": "#/definitions/ptop_internal_models.Offer"
                             }
                         }
                     }
@@ -1425,20 +1548,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.OrderMessage"
+                                "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                             }
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1474,7 +1597,7 @@ const docTemplate = `{
                         "name": "input",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.OrderMessageRequest"
+                            "$ref": "#/definitions/internal_handlers.OrderMessageRequest"
                         }
                     },
                     {
@@ -1488,25 +1611,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.OrderMessage"
+                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1546,19 +1669,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.OrderMessage"
+                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1584,7 +1707,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.PaymentMethod"
+                                "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
                             }
                         }
                     }
@@ -1622,13 +1745,13 @@ const docTemplate = `{
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1636,10 +1759,13 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handlers.AssetWithWallet": {
+        "internal_handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
                     "type": "number"
                 },
                 "description": {
@@ -1665,7 +1791,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ChangePasswordRequest": {
+        "internal_handlers.ChangePasswordRequest": {
             "type": "object",
             "properties": {
                 "confirm_password": {
@@ -1679,7 +1805,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ChangeUsernameRequest": {
+        "internal_handlers.ChangeUsernameRequest": {
             "type": "object",
             "properties": {
                 "new_username": {
@@ -1690,7 +1816,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.CreateClientPaymentMethodRequest": {
+        "internal_handlers.CreateClientPaymentMethodRequest": {
             "type": "object",
             "properties": {
                 "city": {
@@ -1710,7 +1836,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.DebugDepositRequest": {
+        "internal_handlers.DebugDepositRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -1725,7 +1851,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.Disable2FARequest": {
+        "internal_handlers.Disable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1733,7 +1859,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.Enable2FARequest": {
+        "internal_handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1741,7 +1867,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.Enable2FAResponse": {
+        "internal_handlers.Enable2FAResponse": {
             "type": "object",
             "properties": {
                 "secret": {
@@ -1752,7 +1878,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ErrorResponse": {
+        "internal_handlers.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -1760,7 +1886,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.LoginRequest": {
+        "internal_handlers.LoginRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -1774,7 +1900,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.MnemonicWord": {
+        "internal_handlers.MnemonicWord": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1785,7 +1911,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.OfferRequest": {
+        "internal_handlers.OfferRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1823,7 +1949,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.OrderMessageRequest": {
+        "internal_handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
                 "content": {
@@ -1831,7 +1957,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.OrderRequest": {
+        "internal_handlers.OrderRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1845,7 +1971,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ProfileResponse": {
+        "internal_handlers.ProfileResponse": {
             "type": "object",
             "properties": {
                 "pincode_set": {
@@ -1859,7 +1985,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RecoverChallengeResponse": {
+        "internal_handlers.RecoverChallengeResponse": {
             "type": "object",
             "properties": {
                 "positions": {
@@ -1870,7 +1996,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RecoverPhrase": {
+        "internal_handlers.RecoverPhrase": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1881,7 +2007,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RecoverRequest": {
+        "internal_handlers.RecoverRequest": {
             "type": "object",
             "properties": {
                 "new_password": {
@@ -1893,7 +2019,7 @@ const docTemplate = `{
                 "phrases": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.RecoverPhrase"
+                        "$ref": "#/definitions/internal_handlers.RecoverPhrase"
                     }
                 },
                 "username": {
@@ -1901,7 +2027,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RefreshRequest": {
+        "internal_handlers.RefreshRequest": {
             "type": "object",
             "properties": {
                 "refresh_token": {
@@ -1909,7 +2035,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RegenerateMnemonicRequest": {
+        "internal_handlers.RegenerateMnemonicRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1917,18 +2043,18 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RegenerateMnemonicResponse": {
+        "internal_handlers.RegenerateMnemonicResponse": {
             "type": "object",
             "properties": {
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MnemonicWord"
+                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
                     }
                 }
             }
         },
-        "handlers.RegisterRequest": {
+        "internal_handlers.RegisterRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1942,7 +2068,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RegisterResponse": {
+        "internal_handlers.RegisterResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1951,7 +2077,7 @@ const docTemplate = `{
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MnemonicWord"
+                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
                     }
                 },
                 "refresh_token": {
@@ -1959,7 +2085,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.SetPinCodeRequest": {
+        "internal_handlers.SetPinCodeRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1970,7 +2096,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.StatusResponse": {
+        "internal_handlers.StatusResponse": {
             "type": "object",
             "properties": {
                 "status": {
@@ -1978,7 +2104,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.TokenResponse": {
+        "internal_handlers.TokenResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1989,7 +2115,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.VerifyPasswordRequest": {
+        "internal_handlers.VerifyPasswordRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1997,7 +2123,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.VerifyPasswordResponse": {
+        "internal_handlers.VerifyPasswordResponse": {
             "type": "object",
             "properties": {
                 "verified": {
@@ -2005,7 +2131,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.WalletRequest": {
+        "internal_handlers.WalletRequest": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2013,7 +2139,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Asset": {
+        "ptop_internal_models.Asset": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2036,7 +2162,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Balance": {
+        "ptop_internal_models.Balance": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2062,7 +2188,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.ClientPaymentMethod": {
+        "ptop_internal_models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
                 "city": {
@@ -2088,7 +2214,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Country": {
+        "ptop_internal_models.Country": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2099,7 +2225,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Escrow": {
+        "ptop_internal_models.Escrow": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2128,7 +2254,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.FeeSideType": {
+        "ptop_internal_models.FeeSideType": {
             "type": "string",
             "enum": [
                 "sender",
@@ -2141,7 +2267,7 @@ const docTemplate = `{
                 "FeeSideShared"
             ]
         },
-        "models.KycLevelHintType": {
+        "ptop_internal_models.KycLevelHintType": {
             "type": "string",
             "enum": [
                 "low",
@@ -2154,7 +2280,7 @@ const docTemplate = `{
                 "KycLevelHintHigh"
             ]
         },
-        "models.MessageType": {
+        "ptop_internal_models.MessageType": {
             "type": "string",
             "enum": [
                 "TEXT",
@@ -2167,7 +2293,7 @@ const docTemplate = `{
                 "MessageTypeFile"
             ]
         },
-        "models.Offer": {
+        "ptop_internal_models.Offer": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2223,7 +2349,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Order": {
+        "ptop_internal_models.Order": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2263,7 +2389,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/models.OrderStatus"
+                    "$ref": "#/definitions/ptop_internal_models.OrderStatus"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2273,7 +2399,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.OrderMessage": {
+        "ptop_internal_models.OrderMessage": {
             "type": "object",
             "properties": {
                 "chatID": {
@@ -2304,14 +2430,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/models.MessageType"
+                    "$ref": "#/definitions/ptop_internal_models.MessageType"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "models.OrderStatus": {
+        "ptop_internal_models.OrderStatus": {
             "type": "string",
             "enum": [
                 "WAIT_PAYMENT",
@@ -2328,7 +2454,7 @@ const docTemplate = `{
                 "OrderStatusDispute"
             ]
         },
-        "models.PaymentMethod": {
+        "ptop_internal_models.PaymentMethod": {
             "type": "object",
             "properties": {
                 "chargebackWindowHours": {
@@ -2337,11 +2463,11 @@ const docTemplate = `{
                 "countries": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Country"
+                        "$ref": "#/definitions/ptop_internal_models.Country"
                     }
                 },
                 "feeSide": {
-                    "$ref": "#/definitions/models.FeeSideType"
+                    "$ref": "#/definitions/ptop_internal_models.FeeSideType"
                 },
                 "id": {
                     "type": "string"
@@ -2353,7 +2479,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "kycLevelHint": {
-                    "$ref": "#/definitions/models.KycLevelHintType"
+                    "$ref": "#/definitions/ptop_internal_models.KycLevelHintType"
                 },
                 "methodGroup": {
                     "type": "string"
@@ -2378,7 +2504,154 @@ const docTemplate = `{
                 }
             }
         },
-        "models.Wallet": {
+        "ptop_internal_models.TransactionIn": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionInStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "walletID": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionInStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInStatusPending",
+                "TransactionInStatusProcessing",
+                "TransactionInStatusConfirmed",
+                "TransactionInStatusFailed"
+            ]
+        },
+        "ptop_internal_models.TransactionInternal": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromClientID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "orderInfo": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionInternalStatus"
+                },
+                "toClientID": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionInternalStatus": {
+            "type": "string",
+            "enum": [
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInternalStatusProcessing",
+                "TransactionInternalStatusConfirmed",
+                "TransactionInternalStatusFailed"
+            ]
+        },
+        "ptop_internal_models.TransactionOut": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionOutStatus"
+                },
+                "toAddress": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionOutStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "TransactionOutStatusPending",
+                "TransactionOutStatusProcessing",
+                "TransactionOutStatusConfirmed",
+                "TransactionOutStatusFailed",
+                "TransactionOutStatusCancelled"
+            ]
+        },
+        "ptop_internal_models.Wallet": {
             "type": "object",
             "properties": {
                 "assetID": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -23,7 +23,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Asset"
+                                "$ref": "#/definitions/ptop_internal_models.Asset"
                             }
                         }
                     }
@@ -54,7 +54,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.Disable2FARequest"
+                            "$ref": "#/definitions/internal_handlers.Disable2FARequest"
                         }
                     }
                 ],
@@ -62,19 +62,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -104,7 +104,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.Enable2FARequest"
+                            "$ref": "#/definitions/internal_handlers.Enable2FARequest"
                         }
                     }
                 ],
@@ -112,19 +112,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.Enable2FAResponse"
+                            "$ref": "#/definitions/internal_handlers.Enable2FAResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -150,7 +150,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.LoginRequest"
+                            "$ref": "#/definitions/internal_handlers.LoginRequest"
                         }
                     }
                 ],
@@ -158,19 +158,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -194,13 +194,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -230,7 +230,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
+                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicRequest"
                         }
                     }
                 ],
@@ -238,19 +238,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
+                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -280,7 +280,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChangePasswordRequest"
+                            "$ref": "#/definitions/internal_handlers.ChangePasswordRequest"
                         }
                     }
                 ],
@@ -288,19 +288,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -330,7 +330,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.SetPinCodeRequest"
+                            "$ref": "#/definitions/internal_handlers.SetPinCodeRequest"
                         }
                     }
                 ],
@@ -338,19 +338,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -374,13 +374,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ProfileResponse"
+                            "$ref": "#/definitions/internal_handlers.ProfileResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -405,7 +405,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RecoverRequest"
+                            "$ref": "#/definitions/internal_handlers.RecoverRequest"
                         }
                     }
                 ],
@@ -413,25 +413,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -459,13 +459,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RecoverChallengeResponse"
+                            "$ref": "#/definitions/internal_handlers.RecoverChallengeResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -490,7 +490,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RefreshRequest"
+                            "$ref": "#/definitions/internal_handlers.RefreshRequest"
                         }
                     }
                 ],
@@ -498,19 +498,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.TokenResponse"
+                            "$ref": "#/definitions/internal_handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -536,7 +536,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegisterRequest"
+                            "$ref": "#/definitions/internal_handlers.RegisterRequest"
                         }
                     }
                 ],
@@ -544,19 +544,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.RegisterResponse"
+                            "$ref": "#/definitions/internal_handlers.RegisterResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -586,7 +586,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChangeUsernameRequest"
+                            "$ref": "#/definitions/internal_handlers.ChangeUsernameRequest"
                         }
                     }
                 ],
@@ -594,25 +594,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -642,7 +642,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
+                            "$ref": "#/definitions/internal_handlers.VerifyPasswordRequest"
                         }
                     }
                 ],
@@ -650,19 +650,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
+                            "$ref": "#/definitions/internal_handlers.VerifyPasswordResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -688,7 +688,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.AssetWithWallet"
+                                "$ref": "#/definitions/internal_handlers.AssetWithWallet"
                             }
                         }
                     }
@@ -715,7 +715,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Balance"
+                                "$ref": "#/definitions/ptop_internal_models.Balance"
                             }
                         }
                     }
@@ -742,7 +742,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Escrow"
+                                "$ref": "#/definitions/ptop_internal_models.Escrow"
                             }
                         }
                     }
@@ -777,7 +777,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Offer"
+                                "$ref": "#/definitions/ptop_internal_models.Offer"
                             }
                         }
                     }
@@ -806,7 +806,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OfferRequest"
+                            "$ref": "#/definitions/internal_handlers.OfferRequest"
                         }
                     }
                 ],
@@ -814,13 +814,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -857,7 +857,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OfferRequest"
+                            "$ref": "#/definitions/internal_handlers.OfferRequest"
                         }
                     }
                 ],
@@ -865,19 +865,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -907,13 +907,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -943,19 +943,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Offer"
+                            "$ref": "#/definitions/ptop_internal_models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -981,7 +981,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Order"
+                                "$ref": "#/definitions/ptop_internal_models.Order"
                             }
                         }
                     }
@@ -1010,7 +1010,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.OrderRequest"
+                            "$ref": "#/definitions/internal_handlers.OrderRequest"
                         }
                     }
                 ],
@@ -1018,13 +1018,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Order"
+                            "$ref": "#/definitions/ptop_internal_models.Order"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1050,7 +1050,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.ClientPaymentMethod"
+                                "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
                             }
                         }
                     }
@@ -1079,7 +1079,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateClientPaymentMethodRequest"
+                            "$ref": "#/definitions/internal_handlers.CreateClientPaymentMethodRequest"
                         }
                     }
                 ],
@@ -1087,19 +1087,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.ClientPaymentMethod"
+                            "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1129,13 +1129,136 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/in": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список входящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionIn"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/internal": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список внутренних транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionInternal"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/out": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список исходящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ptop_internal_models.TransactionOut"
+                            }
                         }
                     }
                 }
@@ -1161,7 +1284,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Wallet"
+                                "$ref": "#/definitions/ptop_internal_models.Wallet"
                             }
                         }
                     }
@@ -1191,7 +1314,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.WalletRequest"
+                            "$ref": "#/definitions/internal_handlers.WalletRequest"
                         }
                     }
                 ],
@@ -1199,13 +1322,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Wallet"
+                            "$ref": "#/definitions/ptop_internal_models.Wallet"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1231,7 +1354,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Country"
+                                "$ref": "#/definitions/ptop_internal_models.Country"
                             }
                         }
                     }
@@ -1258,7 +1381,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.DebugDepositRequest"
+                            "$ref": "#/definitions/internal_handlers.DebugDepositRequest"
                         }
                     }
                 ],
@@ -1300,13 +1423,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.StatusResponse"
+                            "$ref": "#/definitions/internal_handlers.StatusResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1370,7 +1493,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Offer"
+                                "$ref": "#/definitions/ptop_internal_models.Offer"
                             }
                         }
                     }
@@ -1418,20 +1541,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.OrderMessage"
+                                "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                             }
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1467,7 +1590,7 @@
                         "name": "input",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.OrderMessageRequest"
+                            "$ref": "#/definitions/internal_handlers.OrderMessageRequest"
                         }
                     },
                     {
@@ -1481,25 +1604,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.OrderMessage"
+                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1539,19 +1662,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.OrderMessage"
+                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1577,7 +1700,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.PaymentMethod"
+                                "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
                             }
                         }
                     }
@@ -1615,13 +1738,13 @@
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1629,10 +1752,13 @@
         }
     },
     "definitions": {
-        "handlers.AssetWithWallet": {
+        "internal_handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
                     "type": "number"
                 },
                 "description": {
@@ -1658,7 +1784,7 @@
                 }
             }
         },
-        "handlers.ChangePasswordRequest": {
+        "internal_handlers.ChangePasswordRequest": {
             "type": "object",
             "properties": {
                 "confirm_password": {
@@ -1672,7 +1798,7 @@
                 }
             }
         },
-        "handlers.ChangeUsernameRequest": {
+        "internal_handlers.ChangeUsernameRequest": {
             "type": "object",
             "properties": {
                 "new_username": {
@@ -1683,7 +1809,7 @@
                 }
             }
         },
-        "handlers.CreateClientPaymentMethodRequest": {
+        "internal_handlers.CreateClientPaymentMethodRequest": {
             "type": "object",
             "properties": {
                 "city": {
@@ -1703,7 +1829,7 @@
                 }
             }
         },
-        "handlers.DebugDepositRequest": {
+        "internal_handlers.DebugDepositRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -1718,7 +1844,7 @@
                 }
             }
         },
-        "handlers.Disable2FARequest": {
+        "internal_handlers.Disable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1726,7 +1852,7 @@
                 }
             }
         },
-        "handlers.Enable2FARequest": {
+        "internal_handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1734,7 +1860,7 @@
                 }
             }
         },
-        "handlers.Enable2FAResponse": {
+        "internal_handlers.Enable2FAResponse": {
             "type": "object",
             "properties": {
                 "secret": {
@@ -1745,7 +1871,7 @@
                 }
             }
         },
-        "handlers.ErrorResponse": {
+        "internal_handlers.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -1753,7 +1879,7 @@
                 }
             }
         },
-        "handlers.LoginRequest": {
+        "internal_handlers.LoginRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -1767,7 +1893,7 @@
                 }
             }
         },
-        "handlers.MnemonicWord": {
+        "internal_handlers.MnemonicWord": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1778,7 +1904,7 @@
                 }
             }
         },
-        "handlers.OfferRequest": {
+        "internal_handlers.OfferRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1816,7 +1942,7 @@
                 }
             }
         },
-        "handlers.OrderMessageRequest": {
+        "internal_handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
                 "content": {
@@ -1824,7 +1950,7 @@
                 }
             }
         },
-        "handlers.OrderRequest": {
+        "internal_handlers.OrderRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1838,7 +1964,7 @@
                 }
             }
         },
-        "handlers.ProfileResponse": {
+        "internal_handlers.ProfileResponse": {
             "type": "object",
             "properties": {
                 "pincode_set": {
@@ -1852,7 +1978,7 @@
                 }
             }
         },
-        "handlers.RecoverChallengeResponse": {
+        "internal_handlers.RecoverChallengeResponse": {
             "type": "object",
             "properties": {
                 "positions": {
@@ -1863,7 +1989,7 @@
                 }
             }
         },
-        "handlers.RecoverPhrase": {
+        "internal_handlers.RecoverPhrase": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1874,7 +2000,7 @@
                 }
             }
         },
-        "handlers.RecoverRequest": {
+        "internal_handlers.RecoverRequest": {
             "type": "object",
             "properties": {
                 "new_password": {
@@ -1886,7 +2012,7 @@
                 "phrases": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.RecoverPhrase"
+                        "$ref": "#/definitions/internal_handlers.RecoverPhrase"
                     }
                 },
                 "username": {
@@ -1894,7 +2020,7 @@
                 }
             }
         },
-        "handlers.RefreshRequest": {
+        "internal_handlers.RefreshRequest": {
             "type": "object",
             "properties": {
                 "refresh_token": {
@@ -1902,7 +2028,7 @@
                 }
             }
         },
-        "handlers.RegenerateMnemonicRequest": {
+        "internal_handlers.RegenerateMnemonicRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1910,18 +2036,18 @@
                 }
             }
         },
-        "handlers.RegenerateMnemonicResponse": {
+        "internal_handlers.RegenerateMnemonicResponse": {
             "type": "object",
             "properties": {
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MnemonicWord"
+                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
                     }
                 }
             }
         },
-        "handlers.RegisterRequest": {
+        "internal_handlers.RegisterRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1935,7 +2061,7 @@
                 }
             }
         },
-        "handlers.RegisterResponse": {
+        "internal_handlers.RegisterResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1944,7 +2070,7 @@
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MnemonicWord"
+                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
                     }
                 },
                 "refresh_token": {
@@ -1952,7 +2078,7 @@
                 }
             }
         },
-        "handlers.SetPinCodeRequest": {
+        "internal_handlers.SetPinCodeRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1963,7 +2089,7 @@
                 }
             }
         },
-        "handlers.StatusResponse": {
+        "internal_handlers.StatusResponse": {
             "type": "object",
             "properties": {
                 "status": {
@@ -1971,7 +2097,7 @@
                 }
             }
         },
-        "handlers.TokenResponse": {
+        "internal_handlers.TokenResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -1982,7 +2108,7 @@
                 }
             }
         },
-        "handlers.VerifyPasswordRequest": {
+        "internal_handlers.VerifyPasswordRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1990,7 +2116,7 @@
                 }
             }
         },
-        "handlers.VerifyPasswordResponse": {
+        "internal_handlers.VerifyPasswordResponse": {
             "type": "object",
             "properties": {
                 "verified": {
@@ -1998,7 +2124,7 @@
                 }
             }
         },
-        "handlers.WalletRequest": {
+        "internal_handlers.WalletRequest": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2006,7 +2132,7 @@
                 }
             }
         },
-        "models.Asset": {
+        "ptop_internal_models.Asset": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2029,7 +2155,7 @@
                 }
             }
         },
-        "models.Balance": {
+        "ptop_internal_models.Balance": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2055,7 +2181,7 @@
                 }
             }
         },
-        "models.ClientPaymentMethod": {
+        "ptop_internal_models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
                 "city": {
@@ -2081,7 +2207,7 @@
                 }
             }
         },
-        "models.Country": {
+        "ptop_internal_models.Country": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2092,7 +2218,7 @@
                 }
             }
         },
-        "models.Escrow": {
+        "ptop_internal_models.Escrow": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2121,7 +2247,7 @@
                 }
             }
         },
-        "models.FeeSideType": {
+        "ptop_internal_models.FeeSideType": {
             "type": "string",
             "enum": [
                 "sender",
@@ -2134,7 +2260,7 @@
                 "FeeSideShared"
             ]
         },
-        "models.KycLevelHintType": {
+        "ptop_internal_models.KycLevelHintType": {
             "type": "string",
             "enum": [
                 "low",
@@ -2147,7 +2273,7 @@
                 "KycLevelHintHigh"
             ]
         },
-        "models.MessageType": {
+        "ptop_internal_models.MessageType": {
             "type": "string",
             "enum": [
                 "TEXT",
@@ -2160,7 +2286,7 @@
                 "MessageTypeFile"
             ]
         },
-        "models.Offer": {
+        "ptop_internal_models.Offer": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2216,7 +2342,7 @@
                 }
             }
         },
-        "models.Order": {
+        "ptop_internal_models.Order": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2256,7 +2382,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/models.OrderStatus"
+                    "$ref": "#/definitions/ptop_internal_models.OrderStatus"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2266,7 +2392,7 @@
                 }
             }
         },
-        "models.OrderMessage": {
+        "ptop_internal_models.OrderMessage": {
             "type": "object",
             "properties": {
                 "chatID": {
@@ -2297,14 +2423,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/models.MessageType"
+                    "$ref": "#/definitions/ptop_internal_models.MessageType"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "models.OrderStatus": {
+        "ptop_internal_models.OrderStatus": {
             "type": "string",
             "enum": [
                 "WAIT_PAYMENT",
@@ -2321,7 +2447,7 @@
                 "OrderStatusDispute"
             ]
         },
-        "models.PaymentMethod": {
+        "ptop_internal_models.PaymentMethod": {
             "type": "object",
             "properties": {
                 "chargebackWindowHours": {
@@ -2330,11 +2456,11 @@
                 "countries": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Country"
+                        "$ref": "#/definitions/ptop_internal_models.Country"
                     }
                 },
                 "feeSide": {
-                    "$ref": "#/definitions/models.FeeSideType"
+                    "$ref": "#/definitions/ptop_internal_models.FeeSideType"
                 },
                 "id": {
                     "type": "string"
@@ -2346,7 +2472,7 @@
                     "type": "boolean"
                 },
                 "kycLevelHint": {
-                    "$ref": "#/definitions/models.KycLevelHintType"
+                    "$ref": "#/definitions/ptop_internal_models.KycLevelHintType"
                 },
                 "methodGroup": {
                     "type": "string"
@@ -2371,7 +2497,154 @@
                 }
             }
         },
-        "models.Wallet": {
+        "ptop_internal_models.TransactionIn": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionInStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "walletID": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionInStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInStatusPending",
+                "TransactionInStatusProcessing",
+                "TransactionInStatusConfirmed",
+                "TransactionInStatusFailed"
+            ]
+        },
+        "ptop_internal_models.TransactionInternal": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromClientID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "orderInfo": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionInternalStatus"
+                },
+                "toClientID": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionInternalStatus": {
+            "type": "string",
+            "enum": [
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInternalStatusProcessing",
+                "TransactionInternalStatusConfirmed",
+                "TransactionInternalStatusFailed"
+            ]
+        },
+        "ptop_internal_models.TransactionOut": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ptop_internal_models.TransactionOutStatus"
+                },
+                "toAddress": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "ptop_internal_models.TransactionOutStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "TransactionOutStatusPending",
+                "TransactionOutStatusProcessing",
+                "TransactionOutStatusConfirmed",
+                "TransactionOutStatusFailed",
+                "TransactionOutStatusCancelled"
+            ]
+        },
+        "ptop_internal_models.Wallet": {
             "type": "object",
             "properties": {
                 "assetID": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,8 +1,10 @@
 basePath: /
 definitions:
-  handlers.AssetWithWallet:
+  internal_handlers.AssetWithWallet:
     properties:
       amount:
+        type: number
+      amountEscrow:
         type: number
       description:
         type: string
@@ -19,7 +21,7 @@ definitions:
       value:
         type: string
     type: object
-  handlers.ChangePasswordRequest:
+  internal_handlers.ChangePasswordRequest:
     properties:
       confirm_password:
         type: string
@@ -28,14 +30,14 @@ definitions:
       old_password:
         type: string
     type: object
-  handlers.ChangeUsernameRequest:
+  internal_handlers.ChangeUsernameRequest:
     properties:
       new_username:
         type: string
       password:
         type: string
     type: object
-  handlers.CreateClientPaymentMethodRequest:
+  internal_handlers.CreateClientPaymentMethodRequest:
     properties:
       city:
         type: string
@@ -48,7 +50,7 @@ definitions:
       post_code:
         type: string
     type: object
-  handlers.DebugDepositRequest:
+  internal_handlers.DebugDepositRequest:
     properties:
       amount:
         type: string
@@ -58,29 +60,29 @@ definitions:
     - amount
     - wallet_id
     type: object
-  handlers.Disable2FARequest:
+  internal_handlers.Disable2FARequest:
     properties:
       password:
         type: string
     type: object
-  handlers.Enable2FARequest:
+  internal_handlers.Enable2FARequest:
     properties:
       password:
         type: string
     type: object
-  handlers.Enable2FAResponse:
+  internal_handlers.Enable2FAResponse:
     properties:
       secret:
         type: string
       url:
         type: string
     type: object
-  handlers.ErrorResponse:
+  internal_handlers.ErrorResponse:
     properties:
       error:
         type: string
     type: object
-  handlers.LoginRequest:
+  internal_handlers.LoginRequest:
     properties:
       code:
         type: string
@@ -89,14 +91,14 @@ definitions:
       username:
         type: string
     type: object
-  handlers.MnemonicWord:
+  internal_handlers.MnemonicWord:
     properties:
       position:
         type: integer
       word:
         type: string
     type: object
-  handlers.OfferRequest:
+  internal_handlers.OfferRequest:
     properties:
       amount:
         type: string
@@ -121,12 +123,12 @@ definitions:
       type:
         type: string
     type: object
-  handlers.OrderMessageRequest:
+  internal_handlers.OrderMessageRequest:
     properties:
       content:
         type: string
     type: object
-  handlers.OrderRequest:
+  internal_handlers.OrderRequest:
     properties:
       amount:
         type: string
@@ -135,7 +137,7 @@ definitions:
       offer_id:
         type: string
     type: object
-  handlers.ProfileResponse:
+  internal_handlers.ProfileResponse:
     properties:
       pincode_set:
         type: boolean
@@ -144,21 +146,21 @@ definitions:
       username:
         type: string
     type: object
-  handlers.RecoverChallengeResponse:
+  internal_handlers.RecoverChallengeResponse:
     properties:
       positions:
         items:
           type: integer
         type: array
     type: object
-  handlers.RecoverPhrase:
+  internal_handlers.RecoverPhrase:
     properties:
       position:
         type: integer
       word:
         type: string
     type: object
-  handlers.RecoverRequest:
+  internal_handlers.RecoverRequest:
     properties:
       new_password:
         type: string
@@ -166,29 +168,29 @@ definitions:
         type: string
       phrases:
         items:
-          $ref: '#/definitions/handlers.RecoverPhrase'
+          $ref: '#/definitions/internal_handlers.RecoverPhrase'
         type: array
       username:
         type: string
     type: object
-  handlers.RefreshRequest:
+  internal_handlers.RefreshRequest:
     properties:
       refresh_token:
         type: string
     type: object
-  handlers.RegenerateMnemonicRequest:
+  internal_handlers.RegenerateMnemonicRequest:
     properties:
       password:
         type: string
     type: object
-  handlers.RegenerateMnemonicResponse:
+  internal_handlers.RegenerateMnemonicResponse:
     properties:
       mnemonic:
         items:
-          $ref: '#/definitions/handlers.MnemonicWord'
+          $ref: '#/definitions/internal_handlers.MnemonicWord'
         type: array
     type: object
-  handlers.RegisterRequest:
+  internal_handlers.RegisterRequest:
     properties:
       password:
         type: string
@@ -197,52 +199,52 @@ definitions:
       username:
         type: string
     type: object
-  handlers.RegisterResponse:
+  internal_handlers.RegisterResponse:
     properties:
       access_token:
         type: string
       mnemonic:
         items:
-          $ref: '#/definitions/handlers.MnemonicWord'
+          $ref: '#/definitions/internal_handlers.MnemonicWord'
         type: array
       refresh_token:
         type: string
     type: object
-  handlers.SetPinCodeRequest:
+  internal_handlers.SetPinCodeRequest:
     properties:
       password:
         type: string
       pincode:
         type: string
     type: object
-  handlers.StatusResponse:
+  internal_handlers.StatusResponse:
     properties:
       status:
         type: string
     type: object
-  handlers.TokenResponse:
+  internal_handlers.TokenResponse:
     properties:
       access_token:
         type: string
       refresh_token:
         type: string
     type: object
-  handlers.VerifyPasswordRequest:
+  internal_handlers.VerifyPasswordRequest:
     properties:
       password:
         type: string
     type: object
-  handlers.VerifyPasswordResponse:
+  internal_handlers.VerifyPasswordResponse:
     properties:
       verified:
         type: boolean
     type: object
-  handlers.WalletRequest:
+  internal_handlers.WalletRequest:
     properties:
       asset_id:
         type: string
     type: object
-  models.Asset:
+  ptop_internal_models.Asset:
     properties:
       description:
         type: string
@@ -257,7 +259,7 @@ definitions:
       type:
         type: string
     type: object
-  models.Balance:
+  ptop_internal_models.Balance:
     properties:
       amount:
         type: number
@@ -274,7 +276,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  models.ClientPaymentMethod:
+  ptop_internal_models.ClientPaymentMethod:
     properties:
       city:
         type: string
@@ -291,14 +293,14 @@ definitions:
       postCode:
         type: string
     type: object
-  models.Country:
+  ptop_internal_models.Country:
     properties:
       id:
         type: string
       name:
         type: string
     type: object
-  models.Escrow:
+  ptop_internal_models.Escrow:
     properties:
       amount:
         type: number
@@ -317,7 +319,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  models.FeeSideType:
+  ptop_internal_models.FeeSideType:
     enum:
     - sender
     - receiver
@@ -327,7 +329,7 @@ definitions:
     - FeeSideSender
     - FeeSideReceiver
     - FeeSideShared
-  models.KycLevelHintType:
+  ptop_internal_models.KycLevelHintType:
     enum:
     - low
     - medium
@@ -337,7 +339,7 @@ definitions:
     - KycLevelHintLow
     - KycLevelHintMedium
     - KycLevelHintHigh
-  models.MessageType:
+  ptop_internal_models.MessageType:
     enum:
     - TEXT
     - SYSTEM
@@ -347,7 +349,7 @@ definitions:
     - MessageTypeText
     - MessageTypeSystem
     - MessageTypeFile
-  models.Offer:
+  ptop_internal_models.Offer:
     properties:
       TTL:
         type: string
@@ -384,7 +386,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  models.Order:
+  ptop_internal_models.Order:
     properties:
       amount:
         type: number
@@ -411,13 +413,13 @@ definitions:
       sellerID:
         type: string
       status:
-        $ref: '#/definitions/models.OrderStatus'
+        $ref: '#/definitions/ptop_internal_models.OrderStatus'
       toAssetID:
         type: string
       updatedAt:
         type: string
     type: object
-  models.OrderMessage:
+  ptop_internal_models.OrderMessage:
     properties:
       chatID:
         type: string
@@ -438,11 +440,11 @@ definitions:
       readAt:
         type: string
       type:
-        $ref: '#/definitions/models.MessageType'
+        $ref: '#/definitions/ptop_internal_models.MessageType'
       updatedAt:
         type: string
     type: object
-  models.OrderStatus:
+  ptop_internal_models.OrderStatus:
     enum:
     - WAIT_PAYMENT
     - PAID
@@ -456,16 +458,16 @@ definitions:
     - OrderStatusReleased
     - OrderStatusCancelled
     - OrderStatusDispute
-  models.PaymentMethod:
+  ptop_internal_models.PaymentMethod:
     properties:
       chargebackWindowHours:
         type: integer
       countries:
         items:
-          $ref: '#/definitions/models.Country'
+          $ref: '#/definitions/ptop_internal_models.Country'
         type: array
       feeSide:
-        $ref: '#/definitions/models.FeeSideType'
+        $ref: '#/definitions/ptop_internal_models.FeeSideType'
       id:
         type: string
       isRealtime:
@@ -473,7 +475,7 @@ definitions:
       isReversible:
         type: boolean
       kycLevelHint:
-        $ref: '#/definitions/models.KycLevelHintType'
+        $ref: '#/definitions/ptop_internal_models.KycLevelHintType'
       methodGroup:
         type: string
       name:
@@ -489,7 +491,110 @@ definitions:
       typicalFiatCCY:
         type: string
     type: object
-  models.Wallet:
+  ptop_internal_models.TransactionIn:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      id:
+        type: string
+      status:
+        $ref: '#/definitions/ptop_internal_models.TransactionInStatus'
+      updatedAt:
+        type: string
+      walletID:
+        type: string
+    type: object
+  ptop_internal_models.TransactionInStatus:
+    enum:
+    - pending
+    - processing
+    - confirmed
+    - failed
+    type: string
+    x-enum-varnames:
+    - TransactionInStatusPending
+    - TransactionInStatusProcessing
+    - TransactionInStatusConfirmed
+    - TransactionInStatusFailed
+  ptop_internal_models.TransactionInternal:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      fromClientID:
+        type: string
+      id:
+        type: string
+      orderInfo:
+        type: string
+      status:
+        $ref: '#/definitions/ptop_internal_models.TransactionInternalStatus'
+      toClientID:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  ptop_internal_models.TransactionInternalStatus:
+    enum:
+    - processing
+    - confirmed
+    - failed
+    type: string
+    x-enum-varnames:
+    - TransactionInternalStatusProcessing
+    - TransactionInternalStatusConfirmed
+    - TransactionInternalStatusFailed
+  ptop_internal_models.TransactionOut:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      fromAddress:
+        type: string
+      id:
+        type: string
+      status:
+        $ref: '#/definitions/ptop_internal_models.TransactionOutStatus'
+      toAddress:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  ptop_internal_models.TransactionOutStatus:
+    enum:
+    - pending
+    - processing
+    - confirmed
+    - failed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - TransactionOutStatusPending
+    - TransactionOutStatusProcessing
+    - TransactionOutStatusConfirmed
+    - TransactionOutStatusFailed
+    - TransactionOutStatusCancelled
+  ptop_internal_models.Wallet:
     properties:
       assetID:
         type: string
@@ -521,7 +626,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Asset'
+              $ref: '#/definitions/ptop_internal_models.Asset'
             type: array
       summary: Список активных активов
       tags:
@@ -536,22 +641,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.Disable2FARequest'
+          $ref: '#/definitions/internal_handlers.Disable2FARequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отключение двухфакторной аутентификации
@@ -567,22 +672,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.Enable2FARequest'
+          $ref: '#/definitions/internal_handlers.Enable2FARequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.Enable2FAResponse'
+            $ref: '#/definitions/internal_handlers.Enable2FAResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Включение двухфакторной аутентификации
@@ -600,22 +705,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.LoginRequest'
+          $ref: '#/definitions/internal_handlers.LoginRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.TokenResponse'
+            $ref: '#/definitions/internal_handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Вход клиента
       tags:
       - auth
@@ -627,11 +732,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Выход клиента
@@ -647,22 +752,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.RegenerateMnemonicRequest'
+          $ref: '#/definitions/internal_handlers.RegenerateMnemonicRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.RegenerateMnemonicResponse'
+            $ref: '#/definitions/internal_handlers.RegenerateMnemonicResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Перегенерация мнемонической фразы
@@ -678,22 +783,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.ChangePasswordRequest'
+          $ref: '#/definitions/internal_handlers.ChangePasswordRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Смена пароля
@@ -709,22 +814,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.SetPinCodeRequest'
+          $ref: '#/definitions/internal_handlers.SetPinCodeRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Установка PIN-кода
@@ -738,11 +843,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.ProfileResponse'
+            $ref: '#/definitions/internal_handlers.ProfileResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Профиль клиента
@@ -758,26 +863,26 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.RecoverRequest'
+          $ref: '#/definitions/internal_handlers.RecoverRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.TokenResponse'
+            $ref: '#/definitions/internal_handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Восстановление доступа
       tags:
       - auth
@@ -795,11 +900,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.RecoverChallengeResponse'
+            $ref: '#/definitions/internal_handlers.RecoverChallengeResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Запрос позиций для восстановления
       tags:
       - auth
@@ -813,22 +918,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.RefreshRequest'
+          $ref: '#/definitions/internal_handlers.RefreshRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.TokenResponse'
+            $ref: '#/definitions/internal_handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Обновление access токена
       tags:
       - auth
@@ -844,22 +949,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.RegisterRequest'
+          $ref: '#/definitions/internal_handlers.RegisterRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.RegisterResponse'
+            $ref: '#/definitions/internal_handlers.RegisterResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Регистрация клиента
       tags:
       - auth
@@ -873,26 +978,26 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.ChangeUsernameRequest'
+          $ref: '#/definitions/internal_handlers.ChangeUsernameRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Смена имени пользователя
@@ -908,22 +1013,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.VerifyPasswordRequest'
+          $ref: '#/definitions/internal_handlers.VerifyPasswordRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.VerifyPasswordResponse'
+            $ref: '#/definitions/internal_handlers.VerifyPasswordResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Проверка текущего пароля
@@ -938,7 +1043,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/handlers.AssetWithWallet'
+              $ref: '#/definitions/internal_handlers.AssetWithWallet'
             type: array
       security:
       - BearerAuth: []
@@ -954,7 +1059,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Balance'
+              $ref: '#/definitions/ptop_internal_models.Balance'
             type: array
       security:
       - BearerAuth: []
@@ -970,7 +1075,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Escrow'
+              $ref: '#/definitions/ptop_internal_models.Escrow'
             type: array
       security:
       - BearerAuth: []
@@ -991,7 +1096,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Offer'
+              $ref: '#/definitions/ptop_internal_models.Offer'
             type: array
       security:
       - BearerAuth: []
@@ -1007,18 +1112,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.OfferRequest'
+          $ref: '#/definitions/internal_handlers.OfferRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Offer'
+            $ref: '#/definitions/ptop_internal_models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать объявление
@@ -1039,22 +1144,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.OfferRequest'
+          $ref: '#/definitions/internal_handlers.OfferRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Offer'
+            $ref: '#/definitions/ptop_internal_models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Изменить объявление
@@ -1072,11 +1177,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Offer'
+            $ref: '#/definitions/ptop_internal_models.Offer'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отключить объявление
@@ -1094,15 +1199,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Offer'
+            $ref: '#/definitions/ptop_internal_models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Включить объявление
@@ -1117,7 +1222,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Order'
+              $ref: '#/definitions/ptop_internal_models.Order'
             type: array
       security:
       - BearerAuth: []
@@ -1133,18 +1238,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.OrderRequest'
+          $ref: '#/definitions/internal_handlers.OrderRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Order'
+            $ref: '#/definitions/ptop_internal_models.Order'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать ордер
@@ -1159,7 +1264,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.ClientPaymentMethod'
+              $ref: '#/definitions/ptop_internal_models.ClientPaymentMethod'
             type: array
       security:
       - BearerAuth: []
@@ -1175,22 +1280,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.CreateClientPaymentMethodRequest'
+          $ref: '#/definitions/internal_handlers.CreateClientPaymentMethodRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.ClientPaymentMethod'
+            $ref: '#/definitions/ptop_internal_models.ClientPaymentMethod'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать платёжный метод клиента
@@ -1208,16 +1313,91 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Удалить платёжный метод клиента
       tags:
       - client-payment-methods
+  /client/transactions/in:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/ptop_internal_models.TransactionIn'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список входящих транзакций клиента
+      tags:
+      - transactions
+  /client/transactions/internal:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/ptop_internal_models.TransactionInternal'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список внутренних транзакций клиента
+      tags:
+      - transactions
+  /client/transactions/out:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/ptop_internal_models.TransactionOut'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список исходящих транзакций клиента
+      tags:
+      - transactions
   /client/wallets:
     get:
       produces:
@@ -1227,7 +1407,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Wallet'
+              $ref: '#/definitions/ptop_internal_models.Wallet'
             type: array
       security:
       - BearerAuth: []
@@ -1245,18 +1425,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/handlers.WalletRequest'
+          $ref: '#/definitions/internal_handlers.WalletRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Wallet'
+            $ref: '#/definitions/ptop_internal_models.Wallet'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать кошелёк
@@ -1271,7 +1451,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Country'
+              $ref: '#/definitions/ptop_internal_models.Country'
             type: array
       security:
       - BearerAuth: []
@@ -1289,7 +1469,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.DebugDepositRequest'
+          $ref: '#/definitions/internal_handlers.DebugDepositRequest'
       produces:
       - application/json
       responses:
@@ -1318,11 +1498,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.StatusResponse'
+            $ref: '#/definitions/internal_handlers.StatusResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       summary: Проверка состояния сервиса
       tags:
       - health
@@ -1360,7 +1540,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.Offer'
+              $ref: '#/definitions/ptop_internal_models.Offer'
             type: array
       security:
       - BearerAuth: []
@@ -1390,16 +1570,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.OrderMessage'
+              $ref: '#/definitions/ptop_internal_models.OrderMessage'
             type: array
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Список сообщений ордера
@@ -1420,7 +1600,7 @@ paths:
         in: body
         name: input
         schema:
-          $ref: '#/definitions/handlers.OrderMessageRequest'
+          $ref: '#/definitions/internal_handlers.OrderMessageRequest'
       - description: файл (image/jpeg, image/png, application/pdf)
         in: formData
         name: file
@@ -1431,19 +1611,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.OrderMessage'
+            $ref: '#/definitions/ptop_internal_models.OrderMessage'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отправить сообщение в ордер
@@ -1468,15 +1648,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.OrderMessage'
+            $ref: '#/definitions/ptop_internal_models.OrderMessage'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отметить сообщение прочитанным
@@ -1491,7 +1671,7 @@ paths:
           description: Расширенная структура платёжных методов
           schema:
             items:
-              $ref: '#/definitions/models.PaymentMethod'
+              $ref: '#/definitions/ptop_internal_models.PaymentMethod'
             type: array
       security:
       - BearerAuth: []
@@ -1515,11 +1695,11 @@ paths:
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/internal_handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Websocket чат ордера

--- a/internal/handlers/transaction_test.go
+++ b/internal/handlers/transaction_test.go
@@ -114,18 +114,30 @@ func TestTransactionHandlers(t *testing.T) {
 		t.Fatalf("pagination failed")
 	}
 
-	w = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/client/transactions/out?limit=2", nil)
-	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("out list status %d", w.Code)
-	}
-	var outList []models.TransactionOut
-	json.Unmarshal(w.Body.Bytes(), &outList)
-	if len(outList) != 2 {
-		t.Fatalf("expected 2, got %d", len(outList))
-	}
+        w = httptest.NewRecorder()
+        req, _ = http.NewRequest("GET", "/client/transactions/out?limit=2", nil)
+        req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+        r.ServeHTTP(w, req)
+        if w.Code != http.StatusOK {
+                t.Fatalf("out list status %d", w.Code)
+        }
+        var outList []models.TransactionOut
+        json.Unmarshal(w.Body.Bytes(), &outList)
+        if len(outList) != 2 {
+                t.Fatalf("expected 2, got %d", len(outList))
+        }
+
+        w = httptest.NewRecorder()
+        req, _ = http.NewRequest("GET", "/client/transactions/out?limit=1&offset=1", nil)
+        req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+        r.ServeHTTP(w, req)
+        if w.Code != http.StatusOK {
+                t.Fatalf("out list offset status %d", w.Code)
+        }
+        json.Unmarshal(w.Body.Bytes(), &outList)
+        if len(outList) != 1 || outList[0].ID != tOutOld.ID {
+                t.Fatalf("out pagination failed")
+        }
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/client/transactions/internal?limit=10", nil)

--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -15,7 +15,7 @@ type Client struct {
 	PinCode      *string        `gorm:"type:varchar(255)" json:"pinCode"`
 	TwoFAEnabled bool           `gorm:"not null;default:false" json:"twoFAEnabled"`
 	TOTPSecret   *string        `gorm:"type:varchar(255)" json:"TOTPSecret"`
-	Bip39        datatypes.JSON `gorm:"type:json" json:"bip39"`
+        Bip39        datatypes.JSON `gorm:"type:json" json:"bip39" swaggertype:"object"`
 	Password     *string        `gorm:"type:varchar(255)"`
 	RegistredAt  time.Time      `gorm:"autoCreateTime"`
 }

--- a/internal/models/transaction_in.go
+++ b/internal/models/transaction_in.go
@@ -28,7 +28,7 @@ type TransactionIn struct {
 	Asset     Asset               `gorm:"foreignKey:AssetID" json:"-"`
 	Amount    decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
 	Status    TransactionInStatus `gorm:"type:varchar(20);not null"`
-	Data      datatypes.JSON      `gorm:"type:json"`
+        Data      datatypes.JSON      `gorm:"type:json" swaggertype:"object"`
 	CreatedAt time.Time           `gorm:"autoCreateTime"`
 	UpdatedAt time.Time           `gorm:"autoUpdateTime"`
 }

--- a/internal/models/transaction_internal.go
+++ b/internal/models/transaction_internal.go
@@ -28,7 +28,7 @@ type TransactionInternal struct {
 	ToClientID   string                    `gorm:"size:21"`
 	ToClient     Client                    `gorm:"foreignKey:ToClientID" json:"-"`
 	Status       TransactionInternalStatus `gorm:"type:varchar(20);not null"`
-	Data         datatypes.JSON            `gorm:"type:json"`
+        Data         datatypes.JSON            `gorm:"type:json" swaggertype:"object"`
 	CreatedAt    time.Time                 `gorm:"autoCreateTime"`
 	UpdatedAt    time.Time                 `gorm:"autoUpdateTime"`
 }

--- a/internal/models/transaction_out.go
+++ b/internal/models/transaction_out.go
@@ -29,7 +29,7 @@ type TransactionOut struct {
 	FromAddress string               `gorm:"type:varchar(255)"`
 	ToAddress   string               `gorm:"type:varchar(255)"`
 	Status      TransactionOutStatus `gorm:"type:varchar(20);not null"`
-	Data        datatypes.JSON       `gorm:"type:json"`
+        Data        datatypes.JSON       `gorm:"type:json" swaggertype:"object"`
 	CreatedAt   time.Time            `gorm:"autoCreateTime"`
 	UpdatedAt   time.Time            `gorm:"autoUpdateTime"`
 }


### PR DESCRIPTION
## Изменения
- добавлен тест пагинации исходящих транзакций клиента
- помечены JSON-поля моделей для корректной генерации swagger
- сгенерирована документация swagger для списков транзакций клиента

## Тестирование
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898b3afafd08332956e34bb3776adda