### PR TITLE
Тесты и swagger для транзакций клиента

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1148,6 +1148,129 @@ const docTemplate = `{
                 }
             }
         },
+        "/client/transactions/in": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список входящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionIn"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/internal": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список внутренних транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionInternal"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/out": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список исходящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionOut"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/client/wallets": {
             "get": {
                 "security": [
@@ -1640,6 +1763,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
                     "type": "number"
                 },
                 "description": {
@@ -2289,7 +2415,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "fileType": {
                     "type": "string"
@@ -2377,6 +2504,162 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "models.TransactionIn": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionInStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "walletID": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionInStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInStatusPending",
+                "TransactionInStatusProcessing",
+                "TransactionInStatusConfirmed",
+                "TransactionInStatusFailed"
+            ]
+        },
+        "models.TransactionInternal": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromClientID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "orderInfo": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionInternalStatus"
+                },
+                "toClientID": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionInternalStatus": {
+            "type": "string",
+            "enum": [
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInternalStatusProcessing",
+                "TransactionInternalStatusConfirmed",
+                "TransactionInternalStatusFailed"
+            ]
+        },
+        "models.TransactionOut": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionOutStatus"
+                },
+                "toAddress": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionOutStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "TransactionOutStatusPending",
+                "TransactionOutStatusProcessing",
+                "TransactionOutStatusConfirmed",
+                "TransactionOutStatusFailed",
+                "TransactionOutStatusCancelled"
+            ]
         },
         "models.Wallet": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1141,6 +1141,129 @@
                 }
             }
         },
+        "/client/transactions/in": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список входящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionIn"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/internal": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список внутренних транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionInternal"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client/transactions/out": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactions"
+                ],
+                "summary": "Список исходящих транзакций клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TransactionOut"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/client/wallets": {
             "get": {
                 "security": [
@@ -1633,6 +1756,9 @@
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "number"
+                },
+                "amountEscrow": {
                     "type": "number"
                 },
                 "description": {
@@ -2282,7 +2408,8 @@
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "fileType": {
                     "type": "string"
@@ -2370,6 +2497,162 @@
                     "type": "string"
                 }
             }
+        },
+        "models.TransactionIn": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionInStatus"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "walletID": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionInStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInStatusPending",
+                "TransactionInStatusProcessing",
+                "TransactionInStatusConfirmed",
+                "TransactionInStatusFailed"
+            ]
+        },
+        "models.TransactionInternal": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromClientID": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "orderInfo": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionInternalStatus"
+                },
+                "toClientID": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionInternalStatus": {
+            "type": "string",
+            "enum": [
+                "processing",
+                "confirmed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "TransactionInternalStatusProcessing",
+                "TransactionInternalStatusConfirmed",
+                "TransactionInternalStatusFailed"
+            ]
+        },
+        "models.TransactionOut": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "assetID": {
+                    "type": "string"
+                },
+                "assetName": {
+                    "type": "string"
+                },
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "object"
+                },
+                "fromAddress": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.TransactionOutStatus"
+                },
+                "toAddress": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TransactionOutStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "processing",
+                "confirmed",
+                "failed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "TransactionOutStatusPending",
+                "TransactionOutStatusProcessing",
+                "TransactionOutStatusConfirmed",
+                "TransactionOutStatusFailed",
+                "TransactionOutStatusCancelled"
+            ]
         },
         "models.Wallet": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     properties:
       amount:
         type: number
+      amountEscrow:
+        type: number
       description:
         type: string
       id:
@@ -428,6 +430,7 @@ definitions:
       createdAt:
         type: string
       fileSize:
+        format: int64
         type: integer
       fileType:
         type: string
@@ -489,6 +492,115 @@ definitions:
       typicalFiatCCY:
         type: string
     type: object
+  models.TransactionIn:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      assetName:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      id:
+        type: string
+      status:
+        $ref: '#/definitions/models.TransactionInStatus'
+      updatedAt:
+        type: string
+      walletID:
+        type: string
+    type: object
+  models.TransactionInStatus:
+    enum:
+    - pending
+    - processing
+    - confirmed
+    - failed
+    type: string
+    x-enum-varnames:
+    - TransactionInStatusPending
+    - TransactionInStatusProcessing
+    - TransactionInStatusConfirmed
+    - TransactionInStatusFailed
+  models.TransactionInternal:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      assetName:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      fromClientID:
+        type: string
+      id:
+        type: string
+      orderInfo:
+        type: string
+      status:
+        $ref: '#/definitions/models.TransactionInternalStatus'
+      toClientID:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  models.TransactionInternalStatus:
+    enum:
+    - processing
+    - confirmed
+    - failed
+    type: string
+    x-enum-varnames:
+    - TransactionInternalStatusProcessing
+    - TransactionInternalStatusConfirmed
+    - TransactionInternalStatusFailed
+  models.TransactionOut:
+    properties:
+      amount:
+        type: number
+      assetID:
+        type: string
+      assetName:
+        type: string
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      data:
+        type: object
+      fromAddress:
+        type: string
+      id:
+        type: string
+      status:
+        $ref: '#/definitions/models.TransactionOutStatus'
+      toAddress:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  models.TransactionOutStatus:
+    enum:
+    - pending
+    - processing
+    - confirmed
+    - failed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - TransactionOutStatusPending
+    - TransactionOutStatusProcessing
+    - TransactionOutStatusConfirmed
+    - TransactionOutStatusFailed
+    - TransactionOutStatusCancelled
   models.Wallet:
     properties:
       assetID:
@@ -1218,6 +1330,81 @@ paths:
       summary: Удалить платёжный метод клиента
       tags:
       - client-payment-methods
+  /client/transactions/in:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TransactionIn'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список входящих транзакций клиента
+      tags:
+      - transactions
+  /client/transactions/internal:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TransactionInternal'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список внутренних транзакций клиента
+      tags:
+      - transactions
+  /client/transactions/out:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TransactionOut'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список исходящих транзакций клиента
+      tags:
+      - transactions
   /client/wallets:
     get:
       produces:

--- a/internal/handlers/transaction.go
+++ b/internal/handlers/transaction.go
@@ -44,8 +44,13 @@ func ListClientTransactionsIn(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-		var txs []models.TransactionIn
-		if err := db.Where("client_id = ?", clientID).Order("created_at desc").Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+                var txs []models.TransactionIn
+                if err := db.Model(&models.TransactionIn{}).
+                        Select("transaction_ins.*, assets.name as asset_name").
+                        Joins("LEFT JOIN assets ON assets.id = transaction_ins.asset_id").
+                        Where("transaction_ins.client_id = ?", clientID).
+                        Order("transaction_ins.created_at desc").
+                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
@@ -71,8 +76,13 @@ func ListClientTransactionsOut(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-		var txs []models.TransactionOut
-		if err := db.Where("client_id = ?", clientID).Order("created_at desc").Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+                var txs []models.TransactionOut
+                if err := db.Model(&models.TransactionOut{}).
+                        Select("transaction_outs.*, assets.name as asset_name").
+                        Joins("LEFT JOIN assets ON assets.id = transaction_outs.asset_id").
+                        Where("transaction_outs.client_id = ?", clientID).
+                        Order("transaction_outs.created_at desc").
+                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
@@ -98,8 +108,13 @@ func ListClientTransactionsInternal(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-		var txs []models.TransactionInternal
-		if err := db.Where("from_client_id = ? OR to_client_id = ?", clientID, clientID).Order("created_at desc").Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+                var txs []models.TransactionInternal
+                if err := db.Model(&models.TransactionInternal{}).
+                        Select("transaction_internals.*, assets.name as asset_name").
+                        Joins("LEFT JOIN assets ON assets.id = transaction_internals.asset_id").
+                        Where("transaction_internals.from_client_id = ? OR transaction_internals.to_client_id = ?", clientID, clientID).
+                        Order("transaction_internals.created_at desc").
+                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}

--- a/internal/handlers/transaction_test.go
+++ b/internal/handlers/transaction_test.go
@@ -95,12 +95,15 @@ func TestTransactionHandlers(t *testing.T) {
 	}
 	var inList []models.TransactionIn
 	json.Unmarshal(w.Body.Bytes(), &inList)
-	if len(inList) != 1 {
-		t.Fatalf("expected 1, got %d", len(inList))
-	}
-	if inList[0].ID != tInNew.ID {
-		t.Fatalf("expected newest tx")
-	}
+        if len(inList) != 1 {
+                t.Fatalf("expected 1, got %d", len(inList))
+        }
+        if inList[0].ID != tInNew.ID {
+                t.Fatalf("expected newest tx")
+        }
+        if inList[0].AssetName != asset.Name {
+                t.Fatalf("asset name missing")
+        }
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/client/transactions/in?limit=1&offset=1", nil)
@@ -114,18 +117,33 @@ func TestTransactionHandlers(t *testing.T) {
 		t.Fatalf("pagination failed")
 	}
 
-	w = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/client/transactions/out?limit=2", nil)
-	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("out list status %d", w.Code)
-	}
-	var outList []models.TransactionOut
-	json.Unmarshal(w.Body.Bytes(), &outList)
-	if len(outList) != 2 {
-		t.Fatalf("expected 2, got %d", len(outList))
-	}
+        w = httptest.NewRecorder()
+        req, _ = http.NewRequest("GET", "/client/transactions/out?limit=2", nil)
+        req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+        r.ServeHTTP(w, req)
+        if w.Code != http.StatusOK {
+                t.Fatalf("out list status %d", w.Code)
+        }
+        var outList []models.TransactionOut
+        json.Unmarshal(w.Body.Bytes(), &outList)
+        if len(outList) != 2 {
+                t.Fatalf("expected 2, got %d", len(outList))
+        }
+        if outList[0].AssetName != asset.Name || outList[1].AssetName != asset.Name {
+                t.Fatalf("asset name missing in out list")
+        }
+
+        w = httptest.NewRecorder()
+        req, _ = http.NewRequest("GET", "/client/transactions/out?limit=1&offset=1", nil)
+        req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+        r.ServeHTTP(w, req)
+        if w.Code != http.StatusOK {
+                t.Fatalf("out list offset status %d", w.Code)
+        }
+        json.Unmarshal(w.Body.Bytes(), &outList)
+        if len(outList) != 1 || outList[0].ID != tOutOld.ID {
+                t.Fatalf("out pagination failed")
+        }
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/client/transactions/internal?limit=10", nil)
@@ -136,9 +154,12 @@ func TestTransactionHandlers(t *testing.T) {
 	}
 	var intList []models.TransactionInternal
 	json.Unmarshal(w.Body.Bytes(), &intList)
-	if len(intList) != 2 {
-		t.Fatalf("expected 2, got %d", len(intList))
-	}
+        if len(intList) != 2 {
+                t.Fatalf("expected 2, got %d", len(intList))
+        }
+        if intList[0].AssetName != asset.Name || intList[1].AssetName != asset.Name {
+                t.Fatalf("asset name missing in internal list")
+        }
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/client/transactions/internal?limit=1&offset=1", nil)

--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -15,7 +15,7 @@ type Client struct {
 	PinCode      *string        `gorm:"type:varchar(255)" json:"pinCode"`
 	TwoFAEnabled bool           `gorm:"not null;default:false" json:"twoFAEnabled"`
 	TOTPSecret   *string        `gorm:"type:varchar(255)" json:"TOTPSecret"`
-	Bip39        datatypes.JSON `gorm:"type:json" json:"bip39"`
+        Bip39        datatypes.JSON `gorm:"type:json" json:"bip39" swaggertype:"object"`
 	Password     *string        `gorm:"type:varchar(255)"`
 	RegistredAt  time.Time      `gorm:"autoCreateTime"`
 }

--- a/internal/models/transaction_in.go
+++ b/internal/models/transaction_in.go
@@ -24,11 +24,12 @@ type TransactionIn struct {
 	Client    Client              `gorm:"foreignKey:ClientID" json:"-"`
 	WalletID  string              `gorm:"size:21;not null"`
 	Wallet    Wallet              `gorm:"foreignKey:WalletID" json:"-"`
-	AssetID   string              `gorm:"size:21;not null"`
-	Asset     Asset               `gorm:"foreignKey:AssetID" json:"-"`
+        AssetID   string              `gorm:"size:21;not null"`
+        Asset     Asset               `gorm:"foreignKey:AssetID" json:"-"`
+        AssetName string              `gorm:"->;column:asset_name" json:"assetName"`
 	Amount    decimal.Decimal     `gorm:"type:decimal(32,8);not null"`
 	Status    TransactionInStatus `gorm:"type:varchar(20);not null"`
-	Data      datatypes.JSON      `gorm:"type:json"`
+        Data      datatypes.JSON      `gorm:"type:json" swaggertype:"object"`
 	CreatedAt time.Time           `gorm:"autoCreateTime"`
 	UpdatedAt time.Time           `gorm:"autoUpdateTime"`
 }

--- a/internal/models/transaction_internal.go
+++ b/internal/models/transaction_internal.go
@@ -19,8 +19,9 @@ const (
 
 type TransactionInternal struct {
 	ID           string                    `gorm:"primaryKey;size:21"`
-	AssetID      string                    `gorm:"size:21;not null"`
-	Asset        Asset                     `gorm:"foreignKey:AssetID" json:"-"`
+        AssetID      string                    `gorm:"size:21;not null"`
+        Asset        Asset                     `gorm:"foreignKey:AssetID" json:"-"`
+        AssetName    string                    `gorm:"->;column:asset_name" json:"assetName"`
 	Amount       decimal.Decimal           `gorm:"type:decimal(32,8);not null"`
 	OrderInfo    string                    `gorm:"type:text"`
 	FromClientID string                    `gorm:"size:21"`
@@ -28,7 +29,7 @@ type TransactionInternal struct {
 	ToClientID   string                    `gorm:"size:21"`
 	ToClient     Client                    `gorm:"foreignKey:ToClientID" json:"-"`
 	Status       TransactionInternalStatus `gorm:"type:varchar(20);not null"`
-	Data         datatypes.JSON            `gorm:"type:json"`
+        Data         datatypes.JSON            `gorm:"type:json" swaggertype:"object"`
 	CreatedAt    time.Time                 `gorm:"autoCreateTime"`
 	UpdatedAt    time.Time                 `gorm:"autoUpdateTime"`
 }

--- a/internal/models/transaction_out.go
+++ b/internal/models/transaction_out.go
@@ -23,13 +23,14 @@ type TransactionOut struct {
 	ID          string               `gorm:"primaryKey;size:21"`
 	ClientID    string               `gorm:"size:21;not null"`
 	Client      Client               `gorm:"foreignKey:ClientID" json:"-"`
-	AssetID     string               `gorm:"size:21;not null"`
-	Asset       Asset                `gorm:"foreignKey:AssetID" json:"-"`
+        AssetID     string               `gorm:"size:21;not null"`
+        Asset       Asset                `gorm:"foreignKey:AssetID" json:"-"`
+        AssetName   string               `gorm:"->;column:asset_name" json:"assetName"`
 	Amount      decimal.Decimal      `gorm:"type:decimal(32,8);not null"`
 	FromAddress string               `gorm:"type:varchar(255)"`
 	ToAddress   string               `gorm:"type:varchar(255)"`
 	Status      TransactionOutStatus `gorm:"type:varchar(20);not null"`
-	Data        datatypes.JSON       `gorm:"type:json"`
+        Data        datatypes.JSON       `gorm:"type:json" swaggertype:"object"`
 	CreatedAt   time.Time            `gorm:"autoCreateTime"`
 	UpdatedAt   time.Time            `gorm:"autoUpdateTime"`
 }


### PR DESCRIPTION
## Изменения
- во всех моделях транзакций добавлено поле `assetName`
- хендлеры списков транзакций подтягивают название актива через join
- тесты проверяют присутствие названия актива в ответах
- обновлена swagger-документация

## Тестирование
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898b3afafd08332956e34bb3776adda