### PR TITLE
Расширить выдачу офферов и клиента

### DIFF
--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -5,19 +5,22 @@ import (
 
 	"ptop/internal/utils"
 
+	"github.com/shopspring/decimal"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
 type Client struct {
-	ID           string         `gorm:"primaryKey;size:21" json:"id"`
-	Username     string         `gorm:"type:varchar(255);not null;unique" json:"username"`
-	PinCode      *string        `gorm:"type:varchar(255)" json:"pinCode"`
-	TwoFAEnabled bool           `gorm:"not null;default:false" json:"twoFAEnabled"`
-	TOTPSecret   *string        `gorm:"type:varchar(255)" json:"TOTPSecret"`
-        Bip39        datatypes.JSON `gorm:"type:json" json:"bip39" swaggertype:"object"`
-	Password     *string        `gorm:"type:varchar(255)"`
-	RegistredAt  time.Time      `gorm:"autoCreateTime"`
+	ID           string          `gorm:"primaryKey;size:21" json:"id"`
+	Username     string          `gorm:"type:varchar(255);not null;unique" json:"username"`
+	PinCode      *string         `gorm:"type:varchar(255)" json:"pinCode"`
+	TwoFAEnabled bool            `gorm:"not null;default:false" json:"twoFAEnabled"`
+	TOTPSecret   *string         `gorm:"type:varchar(255)" json:"TOTPSecret"`
+	Bip39        datatypes.JSON  `gorm:"type:json" json:"bip39" swaggertype:"object"`
+	Password     *string         `gorm:"type:varchar(255)"`
+	RegistredAt  time.Time       `gorm:"autoCreateTime"`
+	Rating       decimal.Decimal `gorm:"type:decimal(3,2);not null;default:0" json:"rating"`
+	OrdersCount  int             `gorm:"not null;default:0" json:"ordersCount"`
 }
 
 func (c *Client) BeforeCreate(tx *gorm.DB) (err error) {

--- a/internal/models/client_payment_method.go
+++ b/internal/models/client_payment_method.go
@@ -6,13 +6,15 @@ import (
 )
 
 type ClientPaymentMethod struct {
-	ID              string `gorm:"primaryKey;size:21"`
-	ClientID        string `gorm:"size:21;not null;uniqueIndex:idx_client_name"`
-	CountryID       string `gorm:"size:21;not null"`
-	PaymentMethodID string `gorm:"size:21;not null"`
-	City            string `gorm:"type:text"`
-	PostCode        string `gorm:"type:text"`
-	Name            string `gorm:"type:varchar(255);not null;uniqueIndex:idx_client_name"`
+	ID              string        `gorm:"primaryKey;size:21" json:"id"`
+	ClientID        string        `gorm:"size:21;not null;uniqueIndex:idx_client_name" json:"clientID"`
+	CountryID       string        `gorm:"size:21;not null" json:"countryID"`
+	PaymentMethodID string        `gorm:"size:21;not null" json:"paymentMethodID"`
+	City            string        `gorm:"type:text" json:"city"`
+	PostCode        string        `gorm:"type:text" json:"postCode"`
+	Name            string        `gorm:"type:varchar(255);not null;uniqueIndex:idx_client_name" json:"name"`
+	Country         Country       `gorm:"foreignKey:CountryID" json:"country"`
+	PaymentMethod   PaymentMethod `gorm:"foreignKey:PaymentMethodID" json:"paymentMethod"`
 }
 
 func (cpm *ClientPaymentMethod) BeforeCreate(tx *gorm.DB) (err error) {

--- a/internal/models/offer_full.go
+++ b/internal/models/offer_full.go
@@ -1,0 +1,13 @@
+package models
+
+// OfferFull представляет объявление с вложенными данными связанных объектов
+// swagger:model
+// содержит оффер, активы, клиента и платёжные методы клиента
+
+type OfferFull struct {
+	Offer
+	FromAsset            Asset                 `json:"fromAsset"`
+	ToAsset              Asset                 `json:"toAsset"`
+	Client               Client                `json:"client"`
+	ClientPaymentMethods []ClientPaymentMethod `json:"clientPaymentMethods"`
+}


### PR DESCRIPTION
## Summary
- добавить рейтинг и количество ордеров клиенту
- возвращать вложенные данные в ListOffers и ListClientOffers
- покрыть новые возможности тестами и swagger

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898c3b6a61083328914e158135cc22c