### PR TITLE
feat: add client escrow navigation handler

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -97,6 +97,8 @@ func main() {
 	api.POST("/client/wallets", handlers.CreateWallet(gormDB))
 	api.GET("/client/assets", handlers.GetClientAssets(gormDB))
 	api.GET("/client/balances", handlers.ListClientBalances(gormDB))
+	api.GET("/client/escrows", handlers.ListClientEscrows(gormDB))
+	api.GET("/client/escrows/:id", handlers.GetClientEscrow(gormDB))
 
 	api.GET("/client/offers", handlers.ListClientOffers(gormDB))
 	api.POST("/client/offers", handlers.CreateOffer(gormDB))

--- a/internal/handlers/escrow.go
+++ b/internal/handlers/escrow.go
@@ -2,12 +2,31 @@ package handlers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 
 	"ptop/internal/models"
 )
+
+type EscrowDetail struct {
+	ID        string          `json:"id"`
+	Client    models.Client   `json:"client"`
+	Asset     models.Asset    `json:"asset"`
+	Amount    decimal.Decimal `json:"amount"`
+	Offer     *models.Offer   `json:"offer,omitempty"`
+	Order     *models.Order   `json:"order,omitempty"`
+	CreatedAt time.Time       `json:"createdAt"`
+	UpdatedAt time.Time       `json:"updatedAt"`
+}
+
+type EscrowNavResponse struct {
+	Escrow EscrowDetail `json:"escrow"`
+	NextID string       `json:"nextId,omitempty"`
+	PrevID string       `json:"prevId,omitempty"`
+}
 
 // ListClientEscrows godoc
 // @Summary Список эскроу клиента
@@ -30,5 +49,88 @@ func ListClientEscrows(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, escrows)
+	}
+}
+
+// GetClientEscrow godoc
+// @Summary Просмотр эскроу клиента
+// @Tags escrows
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "ID эскроу"
+// @Param dir query string false "навигация: next или prev"
+// @Success 200 {object} EscrowNavResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /client/escrows/{id} [get]
+func GetClientEscrow(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		id := c.Param("id")
+		dir := c.Query("dir")
+
+		var esc models.Escrow
+		q := db.Preload("Client").Preload("Asset").Preload("Offer").Preload("Order").Where("client_id = ?", clientID)
+		switch dir {
+		case "next":
+			var base models.Escrow
+			if err := db.Where("id = ? AND client_id = ?", id, clientID).First(&base).Error; err != nil {
+				c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+				return
+			}
+			if err := q.Where("created_at > ?", base.CreatedAt).Order("created_at asc").First(&esc).Error; err != nil {
+				c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+				return
+			}
+		case "prev":
+			var base models.Escrow
+			if err := db.Where("id = ? AND client_id = ?", id, clientID).First(&base).Error; err != nil {
+				c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+				return
+			}
+			if err := q.Where("created_at < ?", base.CreatedAt).Order("created_at desc").First(&esc).Error; err != nil {
+				c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+				return
+			}
+		default:
+			if err := q.Where("id = ?", id).First(&esc).Error; err != nil {
+				c.JSON(http.StatusNotFound, ErrorResponse{Error: "not found"})
+				return
+			}
+		}
+
+		var nextEsc, prevEsc models.Escrow
+		nextID, prevID := "", ""
+		if err := db.Where("client_id = ? AND created_at > ?", clientID, esc.CreatedAt).Order("created_at asc").Select("id").First(&nextEsc).Error; err == nil {
+			nextID = nextEsc.ID
+		}
+		if err := db.Where("client_id = ? AND created_at < ?", clientID, esc.CreatedAt).Order("created_at desc").Select("id").First(&prevEsc).Error; err == nil {
+			prevID = prevEsc.ID
+		}
+
+		resp := EscrowNavResponse{
+			Escrow: EscrowDetail{
+				ID:        esc.ID,
+				Client:    esc.Client,
+				Asset:     esc.Asset,
+				Amount:    esc.Amount,
+				CreatedAt: esc.CreatedAt,
+				UpdatedAt: esc.UpdatedAt,
+			},
+			NextID: nextID,
+			PrevID: prevID,
+		}
+		if esc.OfferID != nil {
+			resp.Escrow.Offer = &esc.Offer
+		}
+		if esc.OrderID != nil {
+			resp.Escrow.Order = &esc.Order
+		}
+
+		c.JSON(http.StatusOK, resp)
 	}
 }

--- a/internal/handlers/escrow_test.go
+++ b/internal/handlers/escrow_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 	"ptop/internal/models"
@@ -59,5 +60,129 @@ func TestEscrowHandler(t *testing.T) {
 	}
 	if list[0].Amount.Cmp(decimal.RequireFromString("1")) != 0 {
 		t.Fatalf("amount mismatch")
+	}
+}
+
+func TestGetEscrowHandler(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	body := `{"username":"escuser2","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"escuser2","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status %d", w.Code)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok)
+
+	var client models.Client
+	db.Where("username = ?", "escuser2").First(&client)
+
+	asset := models.Asset{Name: "BTC_escrow2", Type: models.AssetTypeCrypto, IsActive: true}
+	if err := db.Create(&asset).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+
+	offer := models.Offer{
+		MaxAmount:              decimal.RequireFromString("10"),
+		MinAmount:              decimal.RequireFromString("1"),
+		Amount:                 decimal.RequireFromString("5"),
+		Price:                  decimal.RequireFromString("1"),
+		Type:                   models.OfferTypeBuy,
+		FromAssetID:            asset.ID,
+		ToAssetID:              asset.ID,
+		OrderExpirationTimeout: 15,
+		TTL:                    time.Now().Add(time.Hour),
+		ClientID:               client.ID,
+	}
+	if err := db.Create(&offer).Error; err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	order := models.Order{
+		OfferID:     offer.ID,
+		BuyerID:     client.ID,
+		SellerID:    client.ID,
+		FromAssetID: asset.ID,
+		ToAssetID:   asset.ID,
+		Amount:      decimal.RequireFromString("1"),
+		Price:       decimal.RequireFromString("1"),
+		Status:      models.OrderStatusPaid,
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	if err := db.Create(&order).Error; err != nil {
+		t.Fatalf("order: %v", err)
+	}
+
+	esc1 := models.Escrow{ClientID: client.ID, AssetID: asset.ID, Amount: decimal.RequireFromString("1"), OfferID: &offer.ID, OrderID: &order.ID}
+	if err := db.Create(&esc1).Error; err != nil {
+		t.Fatalf("escrow1: %v", err)
+	}
+	esc2 := models.Escrow{ClientID: client.ID, AssetID: asset.ID, Amount: decimal.RequireFromString("2")}
+	if err := db.Create(&esc2).Error; err != nil {
+		t.Fatalf("escrow2: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/escrows/"+esc1.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get escrow status %d", w.Code)
+	}
+	var resp struct {
+		Escrow struct {
+			ID     string        `json:"id"`
+			Client models.Client `json:"client"`
+			Asset  models.Asset  `json:"asset"`
+			Offer  *models.Offer `json:"offer"`
+			Order  *models.Order `json:"order"`
+		} `json:"escrow"`
+		NextID string `json:"nextId"`
+		PrevID string `json:"prevId"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Escrow.ID != esc1.ID || resp.NextID != esc2.ID || resp.PrevID != "" {
+		t.Fatalf("unexpected nav ids")
+	}
+	if resp.Escrow.Client.ID != client.ID || resp.Escrow.Asset.ID != asset.ID {
+		t.Fatalf("missing related data")
+	}
+	if resp.Escrow.Offer == nil || resp.Escrow.Order == nil {
+		t.Fatalf("expected offer and order")
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/escrows/"+esc1.ID+"?dir=next", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("next escrow status %d", w.Code)
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Escrow.ID != esc2.ID || resp.PrevID != esc1.ID {
+		t.Fatalf("next navigation failed")
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/client/escrows/"+esc2.ID+"?dir=prev", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("prev escrow status %d", w.Code)
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Escrow.ID != esc1.ID {
+		t.Fatalf("prev navigation failed")
 	}
 }

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -99,6 +99,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	api.POST("/client/wallets", CreateWallet(db))
 	api.GET("/client/balances", ListClientBalances(db))
 	api.GET("/client/escrows", ListClientEscrows(db))
+	api.GET("/client/escrows/:id", GetClientEscrow(db))
 	api.GET("/client/transactions/in", ListClientTransactionsIn(db))
 	api.GET("/client/transactions/out", ListClientTransactionsOut(db))
 	api.GET("/client/transactions/internal", ListClientTransactionsInternal(db))


### PR DESCRIPTION
## Summary
- add handler to view client escrows with navigation and related entities
- expose new escrow endpoints in router
- cover escrow navigation with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898c454a644833297418a8feb3a30b6