### PR TITLE
feat: add pagination for offers

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -30,7 +30,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Asset"
+                                "$ref": "#/definitions/models.Asset"
                             }
                         }
                     }
@@ -61,7 +61,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Disable2FARequest"
+                            "$ref": "#/definitions/handlers.Disable2FARequest"
                         }
                     }
                 ],
@@ -69,19 +69,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -111,7 +111,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Enable2FARequest"
+                            "$ref": "#/definitions/handlers.Enable2FARequest"
                         }
                     }
                 ],
@@ -119,19 +119,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Enable2FAResponse"
+                            "$ref": "#/definitions/handlers.Enable2FAResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -157,7 +157,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.LoginRequest"
+                            "$ref": "#/definitions/handlers.LoginRequest"
                         }
                     }
                 ],
@@ -165,19 +165,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -201,13 +201,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -237,7 +237,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicRequest"
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
                         }
                     }
                 ],
@@ -245,19 +245,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicResponse"
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -287,7 +287,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ChangePasswordRequest"
+                            "$ref": "#/definitions/handlers.ChangePasswordRequest"
                         }
                     }
                 ],
@@ -295,19 +295,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -337,7 +337,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.SetPinCodeRequest"
+                            "$ref": "#/definitions/handlers.SetPinCodeRequest"
                         }
                     }
                 ],
@@ -345,19 +345,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -381,13 +381,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ProfileResponse"
+                            "$ref": "#/definitions/handlers.ProfileResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -412,7 +412,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RecoverRequest"
+                            "$ref": "#/definitions/handlers.RecoverRequest"
                         }
                     }
                 ],
@@ -420,25 +420,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -466,13 +466,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RecoverChallengeResponse"
+                            "$ref": "#/definitions/handlers.RecoverChallengeResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -497,7 +497,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RefreshRequest"
+                            "$ref": "#/definitions/handlers.RefreshRequest"
                         }
                     }
                 ],
@@ -505,19 +505,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -543,7 +543,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegisterRequest"
+                            "$ref": "#/definitions/handlers.RegisterRequest"
                         }
                     }
                 ],
@@ -551,19 +551,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegisterResponse"
+                            "$ref": "#/definitions/handlers.RegisterResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -593,7 +593,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ChangeUsernameRequest"
+                            "$ref": "#/definitions/handlers.ChangeUsernameRequest"
                         }
                     }
                 ],
@@ -601,25 +601,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -649,7 +649,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.VerifyPasswordRequest"
+                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
                         }
                     }
                 ],
@@ -657,19 +657,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.VerifyPasswordResponse"
+                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -695,7 +695,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/internal_handlers.AssetWithWallet"
+                                "$ref": "#/definitions/handlers.AssetWithWallet"
                             }
                         }
                     }
@@ -722,7 +722,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Balance"
+                                "$ref": "#/definitions/models.Balance"
                             }
                         }
                     }
@@ -749,7 +749,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Escrow"
+                                "$ref": "#/definitions/models.Escrow"
                             }
                         }
                     }
@@ -789,13 +789,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.EscrowNavResponse"
+                            "$ref": "#/definitions/handlers.EscrowNavResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -829,7 +829,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OfferFull"
+                                "$ref": "#/definitions/models.OfferFull"
                             }
                         }
                     }
@@ -858,7 +858,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OfferRequest"
+                            "$ref": "#/definitions/handlers.OfferRequest"
                         }
                     }
                 ],
@@ -866,13 +866,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -909,7 +909,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OfferRequest"
+                            "$ref": "#/definitions/handlers.OfferRequest"
                         }
                     }
                 ],
@@ -917,19 +917,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -959,13 +959,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -995,19 +995,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1033,7 +1033,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Order"
+                                "$ref": "#/definitions/models.Order"
                             }
                         }
                     }
@@ -1062,7 +1062,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OrderRequest"
+                            "$ref": "#/definitions/handlers.OrderRequest"
                         }
                     }
                 ],
@@ -1070,13 +1070,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Order"
+                            "$ref": "#/definitions/models.Order"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1102,7 +1102,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                                "$ref": "#/definitions/models.ClientPaymentMethod"
                             }
                         }
                     }
@@ -1131,7 +1131,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.CreateClientPaymentMethodRequest"
+                            "$ref": "#/definitions/handlers.CreateClientPaymentMethodRequest"
                         }
                     }
                 ],
@@ -1139,19 +1139,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                            "$ref": "#/definitions/models.ClientPaymentMethod"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1181,13 +1181,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1227,7 +1227,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionIn"
+                                "$ref": "#/definitions/models.TransactionIn"
                             }
                         }
                     }
@@ -1268,7 +1268,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionInternal"
+                                "$ref": "#/definitions/models.TransactionInternal"
                             }
                         }
                     }
@@ -1309,7 +1309,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionOut"
+                                "$ref": "#/definitions/models.TransactionOut"
                             }
                         }
                     }
@@ -1336,7 +1336,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Wallet"
+                                "$ref": "#/definitions/models.Wallet"
                             }
                         }
                     }
@@ -1366,7 +1366,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.WalletRequest"
+                            "$ref": "#/definitions/handlers.WalletRequest"
                         }
                     }
                 ],
@@ -1374,13 +1374,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Wallet"
+                            "$ref": "#/definitions/models.Wallet"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1406,7 +1406,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Country"
+                                "$ref": "#/definitions/models.Country"
                             }
                         }
                     }
@@ -1433,7 +1433,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.DebugDepositRequest"
+                            "$ref": "#/definitions/handlers.DebugDepositRequest"
                         }
                     }
                 ],
@@ -1475,13 +1475,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1537,6 +1537,18 @@ const docTemplate = `{
                         "description": "тип объявления: buy или sell",
                         "name": "type",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1545,7 +1557,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OfferFull"
+                                "$ref": "#/definitions/models.OfferFull"
                             }
                         }
                     }
@@ -1593,20 +1605,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                                "$ref": "#/definitions/models.OrderMessage"
                             }
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1642,7 +1654,7 @@ const docTemplate = `{
                         "name": "input",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OrderMessageRequest"
+                            "$ref": "#/definitions/handlers.OrderMessageRequest"
                         }
                     },
                     {
@@ -1656,25 +1668,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1714,19 +1726,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1752,7 +1764,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
+                                "$ref": "#/definitions/models.PaymentMethod"
                             }
                         }
                     }
@@ -1790,13 +1802,13 @@ const docTemplate = `{
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1804,7 +1816,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "internal_handlers.AssetWithWallet": {
+        "handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1836,7 +1848,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.ChangePasswordRequest": {
+        "handlers.ChangePasswordRequest": {
             "type": "object",
             "properties": {
                 "confirm_password": {
@@ -1850,7 +1862,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.ChangeUsernameRequest": {
+        "handlers.ChangeUsernameRequest": {
             "type": "object",
             "properties": {
                 "new_username": {
@@ -1861,7 +1873,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.CreateClientPaymentMethodRequest": {
+        "handlers.CreateClientPaymentMethodRequest": {
             "type": "object",
             "properties": {
                 "city": {
@@ -1881,7 +1893,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.DebugDepositRequest": {
+        "handlers.DebugDepositRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -1896,7 +1908,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.Disable2FARequest": {
+        "handlers.Disable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1904,7 +1916,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.Enable2FARequest": {
+        "handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1912,7 +1924,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.Enable2FAResponse": {
+        "handlers.Enable2FAResponse": {
             "type": "object",
             "properties": {
                 "secret": {
@@ -1923,7 +1935,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.ErrorResponse": {
+        "handlers.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -1931,17 +1943,17 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.EscrowDetail": {
+        "handlers.EscrowDetail": {
             "type": "object",
             "properties": {
                 "amount": {
                     "type": "number"
                 },
                 "asset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "client": {
-                    "$ref": "#/definitions/ptop_internal_models.Client"
+                    "$ref": "#/definitions/models.Client"
                 },
                 "createdAt": {
                     "type": "string"
@@ -1950,21 +1962,21 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "offer": {
-                    "$ref": "#/definitions/ptop_internal_models.Offer"
+                    "$ref": "#/definitions/models.Offer"
                 },
                 "order": {
-                    "$ref": "#/definitions/ptop_internal_models.Order"
+                    "$ref": "#/definitions/models.Order"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "internal_handlers.EscrowNavResponse": {
+        "handlers.EscrowNavResponse": {
             "type": "object",
             "properties": {
                 "escrow": {
-                    "$ref": "#/definitions/internal_handlers.EscrowDetail"
+                    "$ref": "#/definitions/handlers.EscrowDetail"
                 },
                 "nextId": {
                     "type": "string"
@@ -1974,7 +1986,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.LoginRequest": {
+        "handlers.LoginRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -1988,7 +2000,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.MnemonicWord": {
+        "handlers.MnemonicWord": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1999,7 +2011,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.OfferRequest": {
+        "handlers.OfferRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2037,7 +2049,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.OrderMessageRequest": {
+        "handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
                 "content": {
@@ -2045,7 +2057,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.OrderRequest": {
+        "handlers.OrderRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2059,7 +2071,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.ProfileResponse": {
+        "handlers.ProfileResponse": {
             "type": "object",
             "properties": {
                 "pincode_set": {
@@ -2073,7 +2085,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RecoverChallengeResponse": {
+        "handlers.RecoverChallengeResponse": {
             "type": "object",
             "properties": {
                 "positions": {
@@ -2084,7 +2096,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RecoverPhrase": {
+        "handlers.RecoverPhrase": {
             "type": "object",
             "properties": {
                 "position": {
@@ -2095,7 +2107,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RecoverRequest": {
+        "handlers.RecoverRequest": {
             "type": "object",
             "properties": {
                 "new_password": {
@@ -2107,7 +2119,7 @@ const docTemplate = `{
                 "phrases": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.RecoverPhrase"
+                        "$ref": "#/definitions/handlers.RecoverPhrase"
                     }
                 },
                 "username": {
@@ -2115,7 +2127,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RefreshRequest": {
+        "handlers.RefreshRequest": {
             "type": "object",
             "properties": {
                 "refresh_token": {
@@ -2123,7 +2135,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RegenerateMnemonicRequest": {
+        "handlers.RegenerateMnemonicRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2131,18 +2143,18 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RegenerateMnemonicResponse": {
+        "handlers.RegenerateMnemonicResponse": {
             "type": "object",
             "properties": {
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
+                        "$ref": "#/definitions/handlers.MnemonicWord"
                     }
                 }
             }
         },
-        "internal_handlers.RegisterRequest": {
+        "handlers.RegisterRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2156,7 +2168,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.RegisterResponse": {
+        "handlers.RegisterResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2165,7 +2177,7 @@ const docTemplate = `{
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
+                        "$ref": "#/definitions/handlers.MnemonicWord"
                     }
                 },
                 "refresh_token": {
@@ -2173,7 +2185,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.SetPinCodeRequest": {
+        "handlers.SetPinCodeRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2184,7 +2196,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.StatusResponse": {
+        "handlers.StatusResponse": {
             "type": "object",
             "properties": {
                 "status": {
@@ -2192,7 +2204,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.TokenResponse": {
+        "handlers.TokenResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2203,7 +2215,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.VerifyPasswordRequest": {
+        "handlers.VerifyPasswordRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2211,7 +2223,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.VerifyPasswordResponse": {
+        "handlers.VerifyPasswordResponse": {
             "type": "object",
             "properties": {
                 "verified": {
@@ -2219,7 +2231,7 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handlers.WalletRequest": {
+        "handlers.WalletRequest": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2227,7 +2239,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Asset": {
+        "models.Asset": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2250,7 +2262,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Balance": {
+        "models.Balance": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2276,7 +2288,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Client": {
+        "models.Client": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2299,7 +2311,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.ClientPaymentMethod": {
+        "models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
                 "city": {
@@ -2309,7 +2321,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "country": {
-                    "$ref": "#/definitions/ptop_internal_models.Country"
+                    "$ref": "#/definitions/models.Country"
                 },
                 "countryID": {
                     "type": "string"
@@ -2321,7 +2333,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "paymentMethod": {
-                    "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
+                    "$ref": "#/definitions/models.PaymentMethod"
                 },
                 "paymentMethodID": {
                     "type": "string"
@@ -2331,7 +2343,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Country": {
+        "models.Country": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2342,7 +2354,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Escrow": {
+        "models.Escrow": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2371,7 +2383,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.FeeSideType": {
+        "models.FeeSideType": {
             "type": "string",
             "enum": [
                 "sender",
@@ -2384,7 +2396,7 @@ const docTemplate = `{
                 "FeeSideShared"
             ]
         },
-        "ptop_internal_models.KycLevelHintType": {
+        "models.KycLevelHintType": {
             "type": "string",
             "enum": [
                 "low",
@@ -2397,7 +2409,7 @@ const docTemplate = `{
                 "KycLevelHintHigh"
             ]
         },
-        "ptop_internal_models.MessageType": {
+        "models.MessageType": {
             "type": "string",
             "enum": [
                 "TEXT",
@@ -2410,7 +2422,7 @@ const docTemplate = `{
                 "MessageTypeFile"
             ]
         },
-        "ptop_internal_models.Offer": {
+        "models.Offer": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2466,7 +2478,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.OfferFull": {
+        "models.OfferFull": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2476,7 +2488,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "client": {
-                    "$ref": "#/definitions/ptop_internal_models.Client"
+                    "$ref": "#/definitions/models.Client"
                 },
                 "clientID": {
                     "type": "string"
@@ -2484,7 +2496,7 @@ const docTemplate = `{
                 "clientPaymentMethods": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                        "$ref": "#/definitions/models.ClientPaymentMethod"
                     }
                 },
                 "conditions": {
@@ -2500,7 +2512,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "fromAsset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "fromAssetID": {
                     "type": "string"
@@ -2524,7 +2536,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "toAsset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2537,7 +2549,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.Order": {
+        "models.Order": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2577,7 +2589,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.OrderStatus"
+                    "$ref": "#/definitions/models.OrderStatus"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2587,7 +2599,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.OrderMessage": {
+        "models.OrderMessage": {
             "type": "object",
             "properties": {
                 "chatID": {
@@ -2619,14 +2631,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/ptop_internal_models.MessageType"
+                    "$ref": "#/definitions/models.MessageType"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "ptop_internal_models.OrderStatus": {
+        "models.OrderStatus": {
             "type": "string",
             "enum": [
                 "WAIT_PAYMENT",
@@ -2643,7 +2655,7 @@ const docTemplate = `{
                 "OrderStatusDispute"
             ]
         },
-        "ptop_internal_models.PaymentMethod": {
+        "models.PaymentMethod": {
             "type": "object",
             "properties": {
                 "chargebackWindowHours": {
@@ -2652,11 +2664,11 @@ const docTemplate = `{
                 "countries": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ptop_internal_models.Country"
+                        "$ref": "#/definitions/models.Country"
                     }
                 },
                 "feeSide": {
-                    "$ref": "#/definitions/ptop_internal_models.FeeSideType"
+                    "$ref": "#/definitions/models.FeeSideType"
                 },
                 "id": {
                     "type": "string"
@@ -2668,7 +2680,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "kycLevelHint": {
-                    "$ref": "#/definitions/ptop_internal_models.KycLevelHintType"
+                    "$ref": "#/definitions/models.KycLevelHintType"
                 },
                 "methodGroup": {
                     "type": "string"
@@ -2693,7 +2705,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.TransactionIn": {
+        "models.TransactionIn": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2718,7 +2730,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionInStatus"
+                    "$ref": "#/definitions/models.TransactionInStatus"
                 },
                 "updatedAt": {
                     "type": "string"
@@ -2728,7 +2740,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.TransactionInStatus": {
+        "models.TransactionInStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -2743,7 +2755,7 @@ const docTemplate = `{
                 "TransactionInStatusFailed"
             ]
         },
-        "ptop_internal_models.TransactionInternal": {
+        "models.TransactionInternal": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2771,7 +2783,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionInternalStatus"
+                    "$ref": "#/definitions/models.TransactionInternalStatus"
                 },
                 "toClientID": {
                     "type": "string"
@@ -2781,7 +2793,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.TransactionInternalStatus": {
+        "models.TransactionInternalStatus": {
             "type": "string",
             "enum": [
                 "processing",
@@ -2794,7 +2806,7 @@ const docTemplate = `{
                 "TransactionInternalStatusFailed"
             ]
         },
-        "ptop_internal_models.TransactionOut": {
+        "models.TransactionOut": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2822,7 +2834,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionOutStatus"
+                    "$ref": "#/definitions/models.TransactionOutStatus"
                 },
                 "toAddress": {
                     "type": "string"
@@ -2832,7 +2844,7 @@ const docTemplate = `{
                 }
             }
         },
-        "ptop_internal_models.TransactionOutStatus": {
+        "models.TransactionOutStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -2849,7 +2861,7 @@ const docTemplate = `{
                 "TransactionOutStatusCancelled"
             ]
         },
-        "ptop_internal_models.Wallet": {
+        "models.Wallet": {
             "type": "object",
             "properties": {
                 "assetID": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -23,7 +23,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Asset"
+                                "$ref": "#/definitions/models.Asset"
                             }
                         }
                     }
@@ -54,7 +54,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Disable2FARequest"
+                            "$ref": "#/definitions/handlers.Disable2FARequest"
                         }
                     }
                 ],
@@ -62,19 +62,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -104,7 +104,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Enable2FARequest"
+                            "$ref": "#/definitions/handlers.Enable2FARequest"
                         }
                     }
                 ],
@@ -112,19 +112,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.Enable2FAResponse"
+                            "$ref": "#/definitions/handlers.Enable2FAResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -150,7 +150,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.LoginRequest"
+                            "$ref": "#/definitions/handlers.LoginRequest"
                         }
                     }
                 ],
@@ -158,19 +158,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -194,13 +194,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -230,7 +230,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicRequest"
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicRequest"
                         }
                     }
                 ],
@@ -238,19 +238,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegenerateMnemonicResponse"
+                            "$ref": "#/definitions/handlers.RegenerateMnemonicResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -280,7 +280,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ChangePasswordRequest"
+                            "$ref": "#/definitions/handlers.ChangePasswordRequest"
                         }
                     }
                 ],
@@ -288,19 +288,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -330,7 +330,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.SetPinCodeRequest"
+                            "$ref": "#/definitions/handlers.SetPinCodeRequest"
                         }
                     }
                 ],
@@ -338,19 +338,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -374,13 +374,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ProfileResponse"
+                            "$ref": "#/definitions/handlers.ProfileResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -405,7 +405,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RecoverRequest"
+                            "$ref": "#/definitions/handlers.RecoverRequest"
                         }
                     }
                 ],
@@ -413,25 +413,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -459,13 +459,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RecoverChallengeResponse"
+                            "$ref": "#/definitions/handlers.RecoverChallengeResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -490,7 +490,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RefreshRequest"
+                            "$ref": "#/definitions/handlers.RefreshRequest"
                         }
                     }
                 ],
@@ -498,19 +498,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.TokenResponse"
+                            "$ref": "#/definitions/handlers.TokenResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -536,7 +536,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegisterRequest"
+                            "$ref": "#/definitions/handlers.RegisterRequest"
                         }
                     }
                 ],
@@ -544,19 +544,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.RegisterResponse"
+                            "$ref": "#/definitions/handlers.RegisterResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -586,7 +586,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ChangeUsernameRequest"
+                            "$ref": "#/definitions/handlers.ChangeUsernameRequest"
                         }
                     }
                 ],
@@ -594,25 +594,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -642,7 +642,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.VerifyPasswordRequest"
+                            "$ref": "#/definitions/handlers.VerifyPasswordRequest"
                         }
                     }
                 ],
@@ -650,19 +650,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.VerifyPasswordResponse"
+                            "$ref": "#/definitions/handlers.VerifyPasswordResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -688,7 +688,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/internal_handlers.AssetWithWallet"
+                                "$ref": "#/definitions/handlers.AssetWithWallet"
                             }
                         }
                     }
@@ -715,7 +715,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Balance"
+                                "$ref": "#/definitions/models.Balance"
                             }
                         }
                     }
@@ -742,7 +742,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Escrow"
+                                "$ref": "#/definitions/models.Escrow"
                             }
                         }
                     }
@@ -782,13 +782,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.EscrowNavResponse"
+                            "$ref": "#/definitions/handlers.EscrowNavResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -822,7 +822,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OfferFull"
+                                "$ref": "#/definitions/models.OfferFull"
                             }
                         }
                     }
@@ -851,7 +851,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OfferRequest"
+                            "$ref": "#/definitions/handlers.OfferRequest"
                         }
                     }
                 ],
@@ -859,13 +859,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -902,7 +902,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OfferRequest"
+                            "$ref": "#/definitions/handlers.OfferRequest"
                         }
                     }
                 ],
@@ -910,19 +910,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -952,13 +952,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -988,19 +988,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Offer"
+                            "$ref": "#/definitions/models.Offer"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1026,7 +1026,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Order"
+                                "$ref": "#/definitions/models.Order"
                             }
                         }
                     }
@@ -1055,7 +1055,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OrderRequest"
+                            "$ref": "#/definitions/handlers.OrderRequest"
                         }
                     }
                 ],
@@ -1063,13 +1063,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Order"
+                            "$ref": "#/definitions/models.Order"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1095,7 +1095,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                                "$ref": "#/definitions/models.ClientPaymentMethod"
                             }
                         }
                     }
@@ -1124,7 +1124,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.CreateClientPaymentMethodRequest"
+                            "$ref": "#/definitions/handlers.CreateClientPaymentMethodRequest"
                         }
                     }
                 ],
@@ -1132,19 +1132,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                            "$ref": "#/definitions/models.ClientPaymentMethod"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1174,13 +1174,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1220,7 +1220,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionIn"
+                                "$ref": "#/definitions/models.TransactionIn"
                             }
                         }
                     }
@@ -1261,7 +1261,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionInternal"
+                                "$ref": "#/definitions/models.TransactionInternal"
                             }
                         }
                     }
@@ -1302,7 +1302,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.TransactionOut"
+                                "$ref": "#/definitions/models.TransactionOut"
                             }
                         }
                     }
@@ -1329,7 +1329,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Wallet"
+                                "$ref": "#/definitions/models.Wallet"
                             }
                         }
                     }
@@ -1359,7 +1359,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.WalletRequest"
+                            "$ref": "#/definitions/handlers.WalletRequest"
                         }
                     }
                 ],
@@ -1367,13 +1367,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.Wallet"
+                            "$ref": "#/definitions/models.Wallet"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1399,7 +1399,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.Country"
+                                "$ref": "#/definitions/models.Country"
                             }
                         }
                     }
@@ -1426,7 +1426,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.DebugDepositRequest"
+                            "$ref": "#/definitions/handlers.DebugDepositRequest"
                         }
                     }
                 ],
@@ -1468,13 +1468,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.StatusResponse"
+                            "$ref": "#/definitions/handlers.StatusResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1530,6 +1530,18 @@
                         "description": "тип объявления: buy или sell",
                         "name": "type",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1538,7 +1550,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OfferFull"
+                                "$ref": "#/definitions/models.OfferFull"
                             }
                         }
                     }
@@ -1586,20 +1598,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                                "$ref": "#/definitions/models.OrderMessage"
                             }
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1635,7 +1647,7 @@
                         "name": "input",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.OrderMessageRequest"
+                            "$ref": "#/definitions/handlers.OrderMessageRequest"
                         }
                     },
                     {
@@ -1649,25 +1661,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1707,19 +1719,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ptop_internal_models.OrderMessage"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1745,7 +1757,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
+                                "$ref": "#/definitions/models.PaymentMethod"
                             }
                         }
                     }
@@ -1783,13 +1795,13 @@
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_handlers.ErrorResponse"
+                            "$ref": "#/definitions/handlers.ErrorResponse"
                         }
                     }
                 }
@@ -1797,7 +1809,7 @@
         }
     },
     "definitions": {
-        "internal_handlers.AssetWithWallet": {
+        "handlers.AssetWithWallet": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -1829,7 +1841,7 @@
                 }
             }
         },
-        "internal_handlers.ChangePasswordRequest": {
+        "handlers.ChangePasswordRequest": {
             "type": "object",
             "properties": {
                 "confirm_password": {
@@ -1843,7 +1855,7 @@
                 }
             }
         },
-        "internal_handlers.ChangeUsernameRequest": {
+        "handlers.ChangeUsernameRequest": {
             "type": "object",
             "properties": {
                 "new_username": {
@@ -1854,7 +1866,7 @@
                 }
             }
         },
-        "internal_handlers.CreateClientPaymentMethodRequest": {
+        "handlers.CreateClientPaymentMethodRequest": {
             "type": "object",
             "properties": {
                 "city": {
@@ -1874,7 +1886,7 @@
                 }
             }
         },
-        "internal_handlers.DebugDepositRequest": {
+        "handlers.DebugDepositRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -1889,7 +1901,7 @@
                 }
             }
         },
-        "internal_handlers.Disable2FARequest": {
+        "handlers.Disable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1897,7 +1909,7 @@
                 }
             }
         },
-        "internal_handlers.Enable2FARequest": {
+        "handlers.Enable2FARequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -1905,7 +1917,7 @@
                 }
             }
         },
-        "internal_handlers.Enable2FAResponse": {
+        "handlers.Enable2FAResponse": {
             "type": "object",
             "properties": {
                 "secret": {
@@ -1916,7 +1928,7 @@
                 }
             }
         },
-        "internal_handlers.ErrorResponse": {
+        "handlers.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -1924,17 +1936,17 @@
                 }
             }
         },
-        "internal_handlers.EscrowDetail": {
+        "handlers.EscrowDetail": {
             "type": "object",
             "properties": {
                 "amount": {
                     "type": "number"
                 },
                 "asset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "client": {
-                    "$ref": "#/definitions/ptop_internal_models.Client"
+                    "$ref": "#/definitions/models.Client"
                 },
                 "createdAt": {
                     "type": "string"
@@ -1943,21 +1955,21 @@
                     "type": "string"
                 },
                 "offer": {
-                    "$ref": "#/definitions/ptop_internal_models.Offer"
+                    "$ref": "#/definitions/models.Offer"
                 },
                 "order": {
-                    "$ref": "#/definitions/ptop_internal_models.Order"
+                    "$ref": "#/definitions/models.Order"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "internal_handlers.EscrowNavResponse": {
+        "handlers.EscrowNavResponse": {
             "type": "object",
             "properties": {
                 "escrow": {
-                    "$ref": "#/definitions/internal_handlers.EscrowDetail"
+                    "$ref": "#/definitions/handlers.EscrowDetail"
                 },
                 "nextId": {
                     "type": "string"
@@ -1967,7 +1979,7 @@
                 }
             }
         },
-        "internal_handlers.LoginRequest": {
+        "handlers.LoginRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -1981,7 +1993,7 @@
                 }
             }
         },
-        "internal_handlers.MnemonicWord": {
+        "handlers.MnemonicWord": {
             "type": "object",
             "properties": {
                 "position": {
@@ -1992,7 +2004,7 @@
                 }
             }
         },
-        "internal_handlers.OfferRequest": {
+        "handlers.OfferRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2030,7 +2042,7 @@
                 }
             }
         },
-        "internal_handlers.OrderMessageRequest": {
+        "handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
                 "content": {
@@ -2038,7 +2050,7 @@
                 }
             }
         },
-        "internal_handlers.OrderRequest": {
+        "handlers.OrderRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2052,7 +2064,7 @@
                 }
             }
         },
-        "internal_handlers.ProfileResponse": {
+        "handlers.ProfileResponse": {
             "type": "object",
             "properties": {
                 "pincode_set": {
@@ -2066,7 +2078,7 @@
                 }
             }
         },
-        "internal_handlers.RecoverChallengeResponse": {
+        "handlers.RecoverChallengeResponse": {
             "type": "object",
             "properties": {
                 "positions": {
@@ -2077,7 +2089,7 @@
                 }
             }
         },
-        "internal_handlers.RecoverPhrase": {
+        "handlers.RecoverPhrase": {
             "type": "object",
             "properties": {
                 "position": {
@@ -2088,7 +2100,7 @@
                 }
             }
         },
-        "internal_handlers.RecoverRequest": {
+        "handlers.RecoverRequest": {
             "type": "object",
             "properties": {
                 "new_password": {
@@ -2100,7 +2112,7 @@
                 "phrases": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.RecoverPhrase"
+                        "$ref": "#/definitions/handlers.RecoverPhrase"
                     }
                 },
                 "username": {
@@ -2108,7 +2120,7 @@
                 }
             }
         },
-        "internal_handlers.RefreshRequest": {
+        "handlers.RefreshRequest": {
             "type": "object",
             "properties": {
                 "refresh_token": {
@@ -2116,7 +2128,7 @@
                 }
             }
         },
-        "internal_handlers.RegenerateMnemonicRequest": {
+        "handlers.RegenerateMnemonicRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2124,18 +2136,18 @@
                 }
             }
         },
-        "internal_handlers.RegenerateMnemonicResponse": {
+        "handlers.RegenerateMnemonicResponse": {
             "type": "object",
             "properties": {
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
+                        "$ref": "#/definitions/handlers.MnemonicWord"
                     }
                 }
             }
         },
-        "internal_handlers.RegisterRequest": {
+        "handlers.RegisterRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2149,7 +2161,7 @@
                 }
             }
         },
-        "internal_handlers.RegisterResponse": {
+        "handlers.RegisterResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2158,7 +2170,7 @@
                 "mnemonic": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/internal_handlers.MnemonicWord"
+                        "$ref": "#/definitions/handlers.MnemonicWord"
                     }
                 },
                 "refresh_token": {
@@ -2166,7 +2178,7 @@
                 }
             }
         },
-        "internal_handlers.SetPinCodeRequest": {
+        "handlers.SetPinCodeRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2177,7 +2189,7 @@
                 }
             }
         },
-        "internal_handlers.StatusResponse": {
+        "handlers.StatusResponse": {
             "type": "object",
             "properties": {
                 "status": {
@@ -2185,7 +2197,7 @@
                 }
             }
         },
-        "internal_handlers.TokenResponse": {
+        "handlers.TokenResponse": {
             "type": "object",
             "properties": {
                 "access_token": {
@@ -2196,7 +2208,7 @@
                 }
             }
         },
-        "internal_handlers.VerifyPasswordRequest": {
+        "handlers.VerifyPasswordRequest": {
             "type": "object",
             "properties": {
                 "password": {
@@ -2204,7 +2216,7 @@
                 }
             }
         },
-        "internal_handlers.VerifyPasswordResponse": {
+        "handlers.VerifyPasswordResponse": {
             "type": "object",
             "properties": {
                 "verified": {
@@ -2212,7 +2224,7 @@
                 }
             }
         },
-        "internal_handlers.WalletRequest": {
+        "handlers.WalletRequest": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2220,7 +2232,7 @@
                 }
             }
         },
-        "ptop_internal_models.Asset": {
+        "models.Asset": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2243,7 +2255,7 @@
                 }
             }
         },
-        "ptop_internal_models.Balance": {
+        "models.Balance": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2269,7 +2281,7 @@
                 }
             }
         },
-        "ptop_internal_models.Client": {
+        "models.Client": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2292,7 +2304,7 @@
                 }
             }
         },
-        "ptop_internal_models.ClientPaymentMethod": {
+        "models.ClientPaymentMethod": {
             "type": "object",
             "properties": {
                 "city": {
@@ -2302,7 +2314,7 @@
                     "type": "string"
                 },
                 "country": {
-                    "$ref": "#/definitions/ptop_internal_models.Country"
+                    "$ref": "#/definitions/models.Country"
                 },
                 "countryID": {
                     "type": "string"
@@ -2314,7 +2326,7 @@
                     "type": "string"
                 },
                 "paymentMethod": {
-                    "$ref": "#/definitions/ptop_internal_models.PaymentMethod"
+                    "$ref": "#/definitions/models.PaymentMethod"
                 },
                 "paymentMethodID": {
                     "type": "string"
@@ -2324,7 +2336,7 @@
                 }
             }
         },
-        "ptop_internal_models.Country": {
+        "models.Country": {
             "type": "object",
             "properties": {
                 "id": {
@@ -2335,7 +2347,7 @@
                 }
             }
         },
-        "ptop_internal_models.Escrow": {
+        "models.Escrow": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2364,7 +2376,7 @@
                 }
             }
         },
-        "ptop_internal_models.FeeSideType": {
+        "models.FeeSideType": {
             "type": "string",
             "enum": [
                 "sender",
@@ -2377,7 +2389,7 @@
                 "FeeSideShared"
             ]
         },
-        "ptop_internal_models.KycLevelHintType": {
+        "models.KycLevelHintType": {
             "type": "string",
             "enum": [
                 "low",
@@ -2390,7 +2402,7 @@
                 "KycLevelHintHigh"
             ]
         },
-        "ptop_internal_models.MessageType": {
+        "models.MessageType": {
             "type": "string",
             "enum": [
                 "TEXT",
@@ -2403,7 +2415,7 @@
                 "MessageTypeFile"
             ]
         },
-        "ptop_internal_models.Offer": {
+        "models.Offer": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2459,7 +2471,7 @@
                 }
             }
         },
-        "ptop_internal_models.OfferFull": {
+        "models.OfferFull": {
             "type": "object",
             "properties": {
                 "TTL": {
@@ -2469,7 +2481,7 @@
                     "type": "number"
                 },
                 "client": {
-                    "$ref": "#/definitions/ptop_internal_models.Client"
+                    "$ref": "#/definitions/models.Client"
                 },
                 "clientID": {
                     "type": "string"
@@ -2477,7 +2489,7 @@
                 "clientPaymentMethods": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ptop_internal_models.ClientPaymentMethod"
+                        "$ref": "#/definitions/models.ClientPaymentMethod"
                     }
                 },
                 "conditions": {
@@ -2493,7 +2505,7 @@
                     "type": "string"
                 },
                 "fromAsset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "fromAssetID": {
                     "type": "string"
@@ -2517,7 +2529,7 @@
                     "type": "number"
                 },
                 "toAsset": {
-                    "$ref": "#/definitions/ptop_internal_models.Asset"
+                    "$ref": "#/definitions/models.Asset"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2530,7 +2542,7 @@
                 }
             }
         },
-        "ptop_internal_models.Order": {
+        "models.Order": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2570,7 +2582,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.OrderStatus"
+                    "$ref": "#/definitions/models.OrderStatus"
                 },
                 "toAssetID": {
                     "type": "string"
@@ -2580,7 +2592,7 @@
                 }
             }
         },
-        "ptop_internal_models.OrderMessage": {
+        "models.OrderMessage": {
             "type": "object",
             "properties": {
                 "chatID": {
@@ -2612,14 +2624,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/ptop_internal_models.MessageType"
+                    "$ref": "#/definitions/models.MessageType"
                 },
                 "updatedAt": {
                     "type": "string"
                 }
             }
         },
-        "ptop_internal_models.OrderStatus": {
+        "models.OrderStatus": {
             "type": "string",
             "enum": [
                 "WAIT_PAYMENT",
@@ -2636,7 +2648,7 @@
                 "OrderStatusDispute"
             ]
         },
-        "ptop_internal_models.PaymentMethod": {
+        "models.PaymentMethod": {
             "type": "object",
             "properties": {
                 "chargebackWindowHours": {
@@ -2645,11 +2657,11 @@
                 "countries": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ptop_internal_models.Country"
+                        "$ref": "#/definitions/models.Country"
                     }
                 },
                 "feeSide": {
-                    "$ref": "#/definitions/ptop_internal_models.FeeSideType"
+                    "$ref": "#/definitions/models.FeeSideType"
                 },
                 "id": {
                     "type": "string"
@@ -2661,7 +2673,7 @@
                     "type": "boolean"
                 },
                 "kycLevelHint": {
-                    "$ref": "#/definitions/ptop_internal_models.KycLevelHintType"
+                    "$ref": "#/definitions/models.KycLevelHintType"
                 },
                 "methodGroup": {
                     "type": "string"
@@ -2686,7 +2698,7 @@
                 }
             }
         },
-        "ptop_internal_models.TransactionIn": {
+        "models.TransactionIn": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2711,7 +2723,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionInStatus"
+                    "$ref": "#/definitions/models.TransactionInStatus"
                 },
                 "updatedAt": {
                     "type": "string"
@@ -2721,7 +2733,7 @@
                 }
             }
         },
-        "ptop_internal_models.TransactionInStatus": {
+        "models.TransactionInStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -2736,7 +2748,7 @@
                 "TransactionInStatusFailed"
             ]
         },
-        "ptop_internal_models.TransactionInternal": {
+        "models.TransactionInternal": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2764,7 +2776,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionInternalStatus"
+                    "$ref": "#/definitions/models.TransactionInternalStatus"
                 },
                 "toClientID": {
                     "type": "string"
@@ -2774,7 +2786,7 @@
                 }
             }
         },
-        "ptop_internal_models.TransactionInternalStatus": {
+        "models.TransactionInternalStatus": {
             "type": "string",
             "enum": [
                 "processing",
@@ -2787,7 +2799,7 @@
                 "TransactionInternalStatusFailed"
             ]
         },
-        "ptop_internal_models.TransactionOut": {
+        "models.TransactionOut": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -2815,7 +2827,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/ptop_internal_models.TransactionOutStatus"
+                    "$ref": "#/definitions/models.TransactionOutStatus"
                 },
                 "toAddress": {
                     "type": "string"
@@ -2825,7 +2837,7 @@
                 }
             }
         },
-        "ptop_internal_models.TransactionOutStatus": {
+        "models.TransactionOutStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -2842,7 +2854,7 @@
                 "TransactionOutStatusCancelled"
             ]
         },
-        "ptop_internal_models.Wallet": {
+        "models.Wallet": {
             "type": "object",
             "properties": {
                 "assetID": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,6 @@
 basePath: /
 definitions:
-  internal_handlers.AssetWithWallet:
+  handlers.AssetWithWallet:
     properties:
       amount:
         type: number
@@ -21,7 +21,7 @@ definitions:
       value:
         type: string
     type: object
-  internal_handlers.ChangePasswordRequest:
+  handlers.ChangePasswordRequest:
     properties:
       confirm_password:
         type: string
@@ -30,14 +30,14 @@ definitions:
       old_password:
         type: string
     type: object
-  internal_handlers.ChangeUsernameRequest:
+  handlers.ChangeUsernameRequest:
     properties:
       new_username:
         type: string
       password:
         type: string
     type: object
-  internal_handlers.CreateClientPaymentMethodRequest:
+  handlers.CreateClientPaymentMethodRequest:
     properties:
       city:
         type: string
@@ -50,7 +50,7 @@ definitions:
       post_code:
         type: string
     type: object
-  internal_handlers.DebugDepositRequest:
+  handlers.DebugDepositRequest:
     properties:
       amount:
         type: string
@@ -60,57 +60,57 @@ definitions:
     - amount
     - wallet_id
     type: object
-  internal_handlers.Disable2FARequest:
+  handlers.Disable2FARequest:
     properties:
       password:
         type: string
     type: object
-  internal_handlers.Enable2FARequest:
+  handlers.Enable2FARequest:
     properties:
       password:
         type: string
     type: object
-  internal_handlers.Enable2FAResponse:
+  handlers.Enable2FAResponse:
     properties:
       secret:
         type: string
       url:
         type: string
     type: object
-  internal_handlers.ErrorResponse:
+  handlers.ErrorResponse:
     properties:
       error:
         type: string
     type: object
-  internal_handlers.EscrowDetail:
+  handlers.EscrowDetail:
     properties:
       amount:
         type: number
       asset:
-        $ref: '#/definitions/ptop_internal_models.Asset'
+        $ref: '#/definitions/models.Asset'
       client:
-        $ref: '#/definitions/ptop_internal_models.Client'
+        $ref: '#/definitions/models.Client'
       createdAt:
         type: string
       id:
         type: string
       offer:
-        $ref: '#/definitions/ptop_internal_models.Offer'
+        $ref: '#/definitions/models.Offer'
       order:
-        $ref: '#/definitions/ptop_internal_models.Order'
+        $ref: '#/definitions/models.Order'
       updatedAt:
         type: string
     type: object
-  internal_handlers.EscrowNavResponse:
+  handlers.EscrowNavResponse:
     properties:
       escrow:
-        $ref: '#/definitions/internal_handlers.EscrowDetail'
+        $ref: '#/definitions/handlers.EscrowDetail'
       nextId:
         type: string
       prevId:
         type: string
     type: object
-  internal_handlers.LoginRequest:
+  handlers.LoginRequest:
     properties:
       code:
         type: string
@@ -119,14 +119,14 @@ definitions:
       username:
         type: string
     type: object
-  internal_handlers.MnemonicWord:
+  handlers.MnemonicWord:
     properties:
       position:
         type: integer
       word:
         type: string
     type: object
-  internal_handlers.OfferRequest:
+  handlers.OfferRequest:
     properties:
       amount:
         type: string
@@ -151,12 +151,12 @@ definitions:
       type:
         type: string
     type: object
-  internal_handlers.OrderMessageRequest:
+  handlers.OrderMessageRequest:
     properties:
       content:
         type: string
     type: object
-  internal_handlers.OrderRequest:
+  handlers.OrderRequest:
     properties:
       amount:
         type: string
@@ -165,7 +165,7 @@ definitions:
       offer_id:
         type: string
     type: object
-  internal_handlers.ProfileResponse:
+  handlers.ProfileResponse:
     properties:
       pincode_set:
         type: boolean
@@ -174,21 +174,21 @@ definitions:
       username:
         type: string
     type: object
-  internal_handlers.RecoverChallengeResponse:
+  handlers.RecoverChallengeResponse:
     properties:
       positions:
         items:
           type: integer
         type: array
     type: object
-  internal_handlers.RecoverPhrase:
+  handlers.RecoverPhrase:
     properties:
       position:
         type: integer
       word:
         type: string
     type: object
-  internal_handlers.RecoverRequest:
+  handlers.RecoverRequest:
     properties:
       new_password:
         type: string
@@ -196,29 +196,29 @@ definitions:
         type: string
       phrases:
         items:
-          $ref: '#/definitions/internal_handlers.RecoverPhrase'
+          $ref: '#/definitions/handlers.RecoverPhrase'
         type: array
       username:
         type: string
     type: object
-  internal_handlers.RefreshRequest:
+  handlers.RefreshRequest:
     properties:
       refresh_token:
         type: string
     type: object
-  internal_handlers.RegenerateMnemonicRequest:
+  handlers.RegenerateMnemonicRequest:
     properties:
       password:
         type: string
     type: object
-  internal_handlers.RegenerateMnemonicResponse:
+  handlers.RegenerateMnemonicResponse:
     properties:
       mnemonic:
         items:
-          $ref: '#/definitions/internal_handlers.MnemonicWord'
+          $ref: '#/definitions/handlers.MnemonicWord'
         type: array
     type: object
-  internal_handlers.RegisterRequest:
+  handlers.RegisterRequest:
     properties:
       password:
         type: string
@@ -227,52 +227,52 @@ definitions:
       username:
         type: string
     type: object
-  internal_handlers.RegisterResponse:
+  handlers.RegisterResponse:
     properties:
       access_token:
         type: string
       mnemonic:
         items:
-          $ref: '#/definitions/internal_handlers.MnemonicWord'
+          $ref: '#/definitions/handlers.MnemonicWord'
         type: array
       refresh_token:
         type: string
     type: object
-  internal_handlers.SetPinCodeRequest:
+  handlers.SetPinCodeRequest:
     properties:
       password:
         type: string
       pincode:
         type: string
     type: object
-  internal_handlers.StatusResponse:
+  handlers.StatusResponse:
     properties:
       status:
         type: string
     type: object
-  internal_handlers.TokenResponse:
+  handlers.TokenResponse:
     properties:
       access_token:
         type: string
       refresh_token:
         type: string
     type: object
-  internal_handlers.VerifyPasswordRequest:
+  handlers.VerifyPasswordRequest:
     properties:
       password:
         type: string
     type: object
-  internal_handlers.VerifyPasswordResponse:
+  handlers.VerifyPasswordResponse:
     properties:
       verified:
         type: boolean
     type: object
-  internal_handlers.WalletRequest:
+  handlers.WalletRequest:
     properties:
       asset_id:
         type: string
     type: object
-  ptop_internal_models.Asset:
+  models.Asset:
     properties:
       description:
         type: string
@@ -287,7 +287,7 @@ definitions:
       type:
         type: string
     type: object
-  ptop_internal_models.Balance:
+  models.Balance:
     properties:
       amount:
         type: number
@@ -304,7 +304,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.Client:
+  models.Client:
     properties:
       id:
         type: string
@@ -319,14 +319,14 @@ definitions:
       username:
         type: string
     type: object
-  ptop_internal_models.ClientPaymentMethod:
+  models.ClientPaymentMethod:
     properties:
       city:
         type: string
       clientID:
         type: string
       country:
-        $ref: '#/definitions/ptop_internal_models.Country'
+        $ref: '#/definitions/models.Country'
       countryID:
         type: string
       id:
@@ -334,20 +334,20 @@ definitions:
       name:
         type: string
       paymentMethod:
-        $ref: '#/definitions/ptop_internal_models.PaymentMethod'
+        $ref: '#/definitions/models.PaymentMethod'
       paymentMethodID:
         type: string
       postCode:
         type: string
     type: object
-  ptop_internal_models.Country:
+  models.Country:
     properties:
       id:
         type: string
       name:
         type: string
     type: object
-  ptop_internal_models.Escrow:
+  models.Escrow:
     properties:
       amount:
         type: number
@@ -366,7 +366,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.FeeSideType:
+  models.FeeSideType:
     enum:
     - sender
     - receiver
@@ -376,7 +376,7 @@ definitions:
     - FeeSideSender
     - FeeSideReceiver
     - FeeSideShared
-  ptop_internal_models.KycLevelHintType:
+  models.KycLevelHintType:
     enum:
     - low
     - medium
@@ -386,7 +386,7 @@ definitions:
     - KycLevelHintLow
     - KycLevelHintMedium
     - KycLevelHintHigh
-  ptop_internal_models.MessageType:
+  models.MessageType:
     enum:
     - TEXT
     - SYSTEM
@@ -396,7 +396,7 @@ definitions:
     - MessageTypeText
     - MessageTypeSystem
     - MessageTypeFile
-  ptop_internal_models.Offer:
+  models.Offer:
     properties:
       TTL:
         type: string
@@ -433,19 +433,19 @@ definitions:
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.OfferFull:
+  models.OfferFull:
     properties:
       TTL:
         type: string
       amount:
         type: number
       client:
-        $ref: '#/definitions/ptop_internal_models.Client'
+        $ref: '#/definitions/models.Client'
       clientID:
         type: string
       clientPaymentMethods:
         items:
-          $ref: '#/definitions/ptop_internal_models.ClientPaymentMethod'
+          $ref: '#/definitions/models.ClientPaymentMethod'
         type: array
       conditions:
         type: string
@@ -456,7 +456,7 @@ definitions:
       enabledAt:
         type: string
       fromAsset:
-        $ref: '#/definitions/ptop_internal_models.Asset'
+        $ref: '#/definitions/models.Asset'
       fromAssetID:
         type: string
       id:
@@ -472,7 +472,7 @@ definitions:
       price:
         type: number
       toAsset:
-        $ref: '#/definitions/ptop_internal_models.Asset'
+        $ref: '#/definitions/models.Asset'
       toAssetID:
         type: string
       type:
@@ -480,7 +480,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.Order:
+  models.Order:
     properties:
       amount:
         type: number
@@ -507,13 +507,13 @@ definitions:
       sellerID:
         type: string
       status:
-        $ref: '#/definitions/ptop_internal_models.OrderStatus'
+        $ref: '#/definitions/models.OrderStatus'
       toAssetID:
         type: string
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.OrderMessage:
+  models.OrderMessage:
     properties:
       chatID:
         type: string
@@ -535,11 +535,11 @@ definitions:
       readAt:
         type: string
       type:
-        $ref: '#/definitions/ptop_internal_models.MessageType'
+        $ref: '#/definitions/models.MessageType'
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.OrderStatus:
+  models.OrderStatus:
     enum:
     - WAIT_PAYMENT
     - PAID
@@ -553,16 +553,16 @@ definitions:
     - OrderStatusReleased
     - OrderStatusCancelled
     - OrderStatusDispute
-  ptop_internal_models.PaymentMethod:
+  models.PaymentMethod:
     properties:
       chargebackWindowHours:
         type: integer
       countries:
         items:
-          $ref: '#/definitions/ptop_internal_models.Country'
+          $ref: '#/definitions/models.Country'
         type: array
       feeSide:
-        $ref: '#/definitions/ptop_internal_models.FeeSideType'
+        $ref: '#/definitions/models.FeeSideType'
       id:
         type: string
       isRealtime:
@@ -570,7 +570,7 @@ definitions:
       isReversible:
         type: boolean
       kycLevelHint:
-        $ref: '#/definitions/ptop_internal_models.KycLevelHintType'
+        $ref: '#/definitions/models.KycLevelHintType'
       methodGroup:
         type: string
       name:
@@ -586,7 +586,7 @@ definitions:
       typicalFiatCCY:
         type: string
     type: object
-  ptop_internal_models.TransactionIn:
+  models.TransactionIn:
     properties:
       amount:
         type: number
@@ -603,13 +603,13 @@ definitions:
       id:
         type: string
       status:
-        $ref: '#/definitions/ptop_internal_models.TransactionInStatus'
+        $ref: '#/definitions/models.TransactionInStatus'
       updatedAt:
         type: string
       walletID:
         type: string
     type: object
-  ptop_internal_models.TransactionInStatus:
+  models.TransactionInStatus:
     enum:
     - pending
     - processing
@@ -621,7 +621,7 @@ definitions:
     - TransactionInStatusProcessing
     - TransactionInStatusConfirmed
     - TransactionInStatusFailed
-  ptop_internal_models.TransactionInternal:
+  models.TransactionInternal:
     properties:
       amount:
         type: number
@@ -640,13 +640,13 @@ definitions:
       orderInfo:
         type: string
       status:
-        $ref: '#/definitions/ptop_internal_models.TransactionInternalStatus'
+        $ref: '#/definitions/models.TransactionInternalStatus'
       toClientID:
         type: string
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.TransactionInternalStatus:
+  models.TransactionInternalStatus:
     enum:
     - processing
     - confirmed
@@ -656,7 +656,7 @@ definitions:
     - TransactionInternalStatusProcessing
     - TransactionInternalStatusConfirmed
     - TransactionInternalStatusFailed
-  ptop_internal_models.TransactionOut:
+  models.TransactionOut:
     properties:
       amount:
         type: number
@@ -675,13 +675,13 @@ definitions:
       id:
         type: string
       status:
-        $ref: '#/definitions/ptop_internal_models.TransactionOutStatus'
+        $ref: '#/definitions/models.TransactionOutStatus'
       toAddress:
         type: string
       updatedAt:
         type: string
     type: object
-  ptop_internal_models.TransactionOutStatus:
+  models.TransactionOutStatus:
     enum:
     - pending
     - processing
@@ -695,7 +695,7 @@ definitions:
     - TransactionOutStatusConfirmed
     - TransactionOutStatusFailed
     - TransactionOutStatusCancelled
-  ptop_internal_models.Wallet:
+  models.Wallet:
     properties:
       assetID:
         type: string
@@ -727,7 +727,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Asset'
+              $ref: '#/definitions/models.Asset'
             type: array
       summary: Список активных активов
       tags:
@@ -742,22 +742,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.Disable2FARequest'
+          $ref: '#/definitions/handlers.Disable2FARequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отключение двухфакторной аутентификации
@@ -773,22 +773,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.Enable2FARequest'
+          $ref: '#/definitions/handlers.Enable2FARequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.Enable2FAResponse'
+            $ref: '#/definitions/handlers.Enable2FAResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Включение двухфакторной аутентификации
@@ -806,22 +806,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.LoginRequest'
+          $ref: '#/definitions/handlers.LoginRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.TokenResponse'
+            $ref: '#/definitions/handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Вход клиента
       tags:
       - auth
@@ -833,11 +833,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Выход клиента
@@ -853,22 +853,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.RegenerateMnemonicRequest'
+          $ref: '#/definitions/handlers.RegenerateMnemonicRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.RegenerateMnemonicResponse'
+            $ref: '#/definitions/handlers.RegenerateMnemonicResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Перегенерация мнемонической фразы
@@ -884,22 +884,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.ChangePasswordRequest'
+          $ref: '#/definitions/handlers.ChangePasswordRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Смена пароля
@@ -915,22 +915,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.SetPinCodeRequest'
+          $ref: '#/definitions/handlers.SetPinCodeRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Установка PIN-кода
@@ -944,11 +944,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.ProfileResponse'
+            $ref: '#/definitions/handlers.ProfileResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Профиль клиента
@@ -964,26 +964,26 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.RecoverRequest'
+          $ref: '#/definitions/handlers.RecoverRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.TokenResponse'
+            $ref: '#/definitions/handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Восстановление доступа
       tags:
       - auth
@@ -1001,11 +1001,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.RecoverChallengeResponse'
+            $ref: '#/definitions/handlers.RecoverChallengeResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Запрос позиций для восстановления
       tags:
       - auth
@@ -1019,22 +1019,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.RefreshRequest'
+          $ref: '#/definitions/handlers.RefreshRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.TokenResponse'
+            $ref: '#/definitions/handlers.TokenResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Обновление access токена
       tags:
       - auth
@@ -1050,22 +1050,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.RegisterRequest'
+          $ref: '#/definitions/handlers.RegisterRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.RegisterResponse'
+            $ref: '#/definitions/handlers.RegisterResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Регистрация клиента
       tags:
       - auth
@@ -1079,26 +1079,26 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.ChangeUsernameRequest'
+          $ref: '#/definitions/handlers.ChangeUsernameRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Смена имени пользователя
@@ -1114,22 +1114,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.VerifyPasswordRequest'
+          $ref: '#/definitions/handlers.VerifyPasswordRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.VerifyPasswordResponse'
+            $ref: '#/definitions/handlers.VerifyPasswordResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Проверка текущего пароля
@@ -1144,7 +1144,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/internal_handlers.AssetWithWallet'
+              $ref: '#/definitions/handlers.AssetWithWallet'
             type: array
       security:
       - BearerAuth: []
@@ -1160,7 +1160,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Balance'
+              $ref: '#/definitions/models.Balance'
             type: array
       security:
       - BearerAuth: []
@@ -1176,7 +1176,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Escrow'
+              $ref: '#/definitions/models.Escrow'
             type: array
       security:
       - BearerAuth: []
@@ -1201,11 +1201,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.EscrowNavResponse'
+            $ref: '#/definitions/handlers.EscrowNavResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Просмотр эскроу клиента
@@ -1225,7 +1225,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.OfferFull'
+              $ref: '#/definitions/models.OfferFull'
             type: array
       security:
       - BearerAuth: []
@@ -1241,18 +1241,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.OfferRequest'
+          $ref: '#/definitions/handlers.OfferRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Offer'
+            $ref: '#/definitions/models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать объявление
@@ -1273,22 +1273,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.OfferRequest'
+          $ref: '#/definitions/handlers.OfferRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Offer'
+            $ref: '#/definitions/models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Изменить объявление
@@ -1306,11 +1306,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Offer'
+            $ref: '#/definitions/models.Offer'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отключить объявление
@@ -1328,15 +1328,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Offer'
+            $ref: '#/definitions/models.Offer'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Включить объявление
@@ -1351,7 +1351,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Order'
+              $ref: '#/definitions/models.Order'
             type: array
       security:
       - BearerAuth: []
@@ -1367,18 +1367,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.OrderRequest'
+          $ref: '#/definitions/handlers.OrderRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Order'
+            $ref: '#/definitions/models.Order'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать ордер
@@ -1393,7 +1393,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.ClientPaymentMethod'
+              $ref: '#/definitions/models.ClientPaymentMethod'
             type: array
       security:
       - BearerAuth: []
@@ -1409,22 +1409,22 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.CreateClientPaymentMethodRequest'
+          $ref: '#/definitions/handlers.CreateClientPaymentMethodRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.ClientPaymentMethod'
+            $ref: '#/definitions/models.ClientPaymentMethod'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать платёжный метод клиента
@@ -1442,11 +1442,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Удалить платёжный метод клиента
@@ -1470,7 +1470,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.TransactionIn'
+              $ref: '#/definitions/models.TransactionIn'
             type: array
       security:
       - BearerAuth: []
@@ -1495,7 +1495,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.TransactionInternal'
+              $ref: '#/definitions/models.TransactionInternal'
             type: array
       security:
       - BearerAuth: []
@@ -1520,7 +1520,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.TransactionOut'
+              $ref: '#/definitions/models.TransactionOut'
             type: array
       security:
       - BearerAuth: []
@@ -1536,7 +1536,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Wallet'
+              $ref: '#/definitions/models.Wallet'
             type: array
       security:
       - BearerAuth: []
@@ -1554,18 +1554,18 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.WalletRequest'
+          $ref: '#/definitions/handlers.WalletRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.Wallet'
+            $ref: '#/definitions/models.Wallet'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Создать кошелёк
@@ -1580,7 +1580,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.Country'
+              $ref: '#/definitions/models.Country'
             type: array
       security:
       - BearerAuth: []
@@ -1598,7 +1598,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_handlers.DebugDepositRequest'
+          $ref: '#/definitions/handlers.DebugDepositRequest'
       produces:
       - application/json
       responses:
@@ -1627,11 +1627,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_handlers.StatusResponse'
+            $ref: '#/definitions/handlers.StatusResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       summary: Проверка состояния сервиса
       tags:
       - health
@@ -1662,6 +1662,14 @@ paths:
         in: query
         name: type
         type: string
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -1669,7 +1677,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.OfferFull'
+              $ref: '#/definitions/models.OfferFull'
             type: array
       security:
       - BearerAuth: []
@@ -1699,16 +1707,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.OrderMessage'
+              $ref: '#/definitions/models.OrderMessage'
             type: array
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Список сообщений ордера
@@ -1729,7 +1737,7 @@ paths:
         in: body
         name: input
         schema:
-          $ref: '#/definitions/internal_handlers.OrderMessageRequest'
+          $ref: '#/definitions/handlers.OrderMessageRequest'
       - description: файл (image/jpeg, image/png, application/pdf)
         in: formData
         name: file
@@ -1740,19 +1748,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.OrderMessage'
+            $ref: '#/definitions/models.OrderMessage'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отправить сообщение в ордер
@@ -1777,15 +1785,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ptop_internal_models.OrderMessage'
+            $ref: '#/definitions/models.OrderMessage'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Отметить сообщение прочитанным
@@ -1800,7 +1808,7 @@ paths:
           description: Расширенная структура платёжных методов
           schema:
             items:
-              $ref: '#/definitions/ptop_internal_models.PaymentMethod'
+              $ref: '#/definitions/models.PaymentMethod'
             type: array
       security:
       - BearerAuth: []
@@ -1824,11 +1832,11 @@ paths:
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_handlers.ErrorResponse'
+            $ref: '#/definitions/handlers.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Websocket чат ордера

--- a/internal/handlers/pagination.go
+++ b/internal/handlers/pagination.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+func parsePagination(c *gin.Context) (limit, offset int) {
+	limit = 50
+	offset = 0
+	if lStr := c.Query("limit"); lStr != "" {
+		if l, err := strconv.Atoi(lStr); err == nil && l > 0 && l <= 100 {
+			limit = l
+		}
+	}
+	if oStr := c.Query("offset"); oStr != "" {
+		if o, err := strconv.Atoi(oStr); err == nil && o >= 0 {
+			offset = o
+		}
+	}
+	return
+}

--- a/internal/handlers/transaction.go
+++ b/internal/handlers/transaction.go
@@ -2,29 +2,12 @@ package handlers
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
 	"ptop/internal/models"
 )
-
-func parsePagination(c *gin.Context) (limit, offset int) {
-	limit = 50
-	offset = 0
-	if lStr := c.Query("limit"); lStr != "" {
-		if l, err := strconv.Atoi(lStr); err == nil && l > 0 && l <= 100 {
-			limit = l
-		}
-	}
-	if oStr := c.Query("offset"); oStr != "" {
-		if o, err := strconv.Atoi(oStr); err == nil && o >= 0 {
-			offset = o
-		}
-	}
-	return
-}
 
 // ListClientTransactionsIn godoc
 // @Summary Список входящих транзакций клиента
@@ -44,13 +27,13 @@ func ListClientTransactionsIn(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-                var txs []models.TransactionIn
-                if err := db.Model(&models.TransactionIn{}).
-                        Select("transaction_ins.*, assets.name as asset_name").
-                        Joins("LEFT JOIN assets ON assets.id = transaction_ins.asset_id").
-                        Where("transaction_ins.client_id = ?", clientID).
-                        Order("transaction_ins.created_at desc").
-                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+		var txs []models.TransactionIn
+		if err := db.Model(&models.TransactionIn{}).
+			Select("transaction_ins.*, assets.name as asset_name").
+			Joins("LEFT JOIN assets ON assets.id = transaction_ins.asset_id").
+			Where("transaction_ins.client_id = ?", clientID).
+			Order("transaction_ins.created_at desc").
+			Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
@@ -76,13 +59,13 @@ func ListClientTransactionsOut(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-                var txs []models.TransactionOut
-                if err := db.Model(&models.TransactionOut{}).
-                        Select("transaction_outs.*, assets.name as asset_name").
-                        Joins("LEFT JOIN assets ON assets.id = transaction_outs.asset_id").
-                        Where("transaction_outs.client_id = ?", clientID).
-                        Order("transaction_outs.created_at desc").
-                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+		var txs []models.TransactionOut
+		if err := db.Model(&models.TransactionOut{}).
+			Select("transaction_outs.*, assets.name as asset_name").
+			Joins("LEFT JOIN assets ON assets.id = transaction_outs.asset_id").
+			Where("transaction_outs.client_id = ?", clientID).
+			Order("transaction_outs.created_at desc").
+			Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
@@ -108,13 +91,13 @@ func ListClientTransactionsInternal(db *gorm.DB) gin.HandlerFunc {
 		}
 		clientID := clientIDVal.(string)
 		limit, offset := parsePagination(c)
-                var txs []models.TransactionInternal
-                if err := db.Model(&models.TransactionInternal{}).
-                        Select("transaction_internals.*, assets.name as asset_name").
-                        Joins("LEFT JOIN assets ON assets.id = transaction_internals.asset_id").
-                        Where("transaction_internals.from_client_id = ? OR transaction_internals.to_client_id = ?", clientID, clientID).
-                        Order("transaction_internals.created_at desc").
-                        Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
+		var txs []models.TransactionInternal
+		if err := db.Model(&models.TransactionInternal{}).
+			Select("transaction_internals.*, assets.name as asset_name").
+			Joins("LEFT JOIN assets ON assets.id = transaction_internals.asset_id").
+			Where("transaction_internals.from_client_id = ? OR transaction_internals.to_client_id = ?", clientID, clientID).
+			Order("transaction_internals.created_at desc").
+			Limit(limit).Offset(offset).Find(&txs).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}


### PR DESCRIPTION
## Summary
- add pagination parameters to offer listing
- document offer pagination in swagger
- cover offer pagination with tests

## Testing
- `go test -v ./internal/handlers -run TestListOffersPagination -count=1` *(failed: команда зависла)*

------
https://chatgpt.com/codex/tasks/task_e_6898cea2a64c83328dedf8f256efe6ad