### PR TITLE
feat: require pincode for order creation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1078,6 +1078,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2067,6 +2073,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "offer_id": {
+                    "type": "string"
+                },
+                "pin_code": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1071,6 +1071,12 @@
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2060,6 +2066,9 @@
                     "type": "string"
                 },
                 "offer_id": {
+                    "type": "string"
+                },
+                "pin_code": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -164,6 +164,8 @@ definitions:
         type: string
       offer_id:
         type: string
+      pin_code:
+        type: string
     type: object
   handlers.ProfileResponse:
     properties:
@@ -1377,6 +1379,10 @@ paths:
             $ref: '#/definitions/models.Order'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
       security:

--- a/internal/handlers/order_chat_ws_test.go
+++ b/internal/handlers/order_chat_ws_test.go
@@ -62,6 +62,17 @@ func TestOrderChatWS(t *testing.T) {
 	var buyer models.Client
 	db.Where("username = ?", "buyer").First(&buyer)
 
+	// set pincode for buyer
+	w = httptest.NewRecorder()
+	body = `{"password":"pass","pincode":"1234"}`
+	req, _ = http.NewRequest("POST", "/auth/pincode", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer pincode status %d", w.Code)
+	}
+
 	// register hacker
 	w = httptest.NewRecorder()
 	body = `{"username":"hacker","password":"pass","password_confirm":"pass"}`
@@ -105,7 +116,7 @@ func TestOrderChatWS(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	body = `{"offer_id":"` + offer.ID + `","amount":"5"}`
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"1234"}`
 	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
 	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/handlers/order_message_test.go
+++ b/internal/handlers/order_message_test.go
@@ -59,6 +59,17 @@ func TestOrderMessageHandler(t *testing.T) {
 	var buyer models.Client
 	db.Where("username = ?", "buyer").First(&buyer)
 
+	// set pincode for buyer
+	w = httptest.NewRecorder()
+	body = `{"password":"pass","pincode":"1234"}`
+	req, _ = http.NewRequest("POST", "/auth/pincode", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer pincode status %d", w.Code)
+	}
+
 	// register hacker
 	w = httptest.NewRecorder()
 	body = `{"username":"hacker","password":"pass","password_confirm":"pass"}`
@@ -102,7 +113,7 @@ func TestOrderMessageHandler(t *testing.T) {
 	}
 
 	w = httptest.NewRecorder()
-	body = `{"offer_id":"` + offer.ID + `","amount":"5"}`
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"1234"}`
 	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
 	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/handlers/order_test.go
+++ b/internal/handlers/order_test.go
@@ -34,6 +34,17 @@ func TestOrderHandler(t *testing.T) {
 	}
 	json.Unmarshal(w.Body.Bytes(), &tok)
 
+	// set pincode
+	w = httptest.NewRecorder()
+	body = `{"password":"pass","pincode":"1234"}`
+	req, _ = http.NewRequest("POST", "/auth/pincode", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pincode status %d", w.Code)
+	}
+
 	var client models.Client
 	db.Where("username = ?", "orduser").First(&client)
 
@@ -62,6 +73,26 @@ func TestOrderHandler(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	body = `{"offer_id":"` + offer.ID + `","amount":"5"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"0000"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"1234"}`
 	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- require client pincode when creating an order
- add tests for order pincode validation
- document pincode requirement in swagger

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5c27f3ea48332bc595a776bdda6f0