### PR TITLE
fix offers amount filtering

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1556,13 +1556,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "минимальная сумма",
+                        "description": "минимальная сумма диапазона",
                         "name": "min_amount",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "максимальная сумма",
+                        "description": "максимальная сумма диапазона",
                         "name": "max_amount",
                         "in": "query"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1549,13 +1549,13 @@
                     },
                     {
                         "type": "string",
-                        "description": "минимальная сумма",
+                        "description": "минимальная сумма диапазона",
                         "name": "min_amount",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "максимальная сумма",
+                        "description": "максимальная сумма диапазона",
                         "name": "max_amount",
                         "in": "query"
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1718,11 +1718,11 @@ paths:
         in: query
         name: to_asset
         type: string
-      - description: минимальная сумма
+      - description: минимальная сумма диапазона
         in: query
         name: min_amount
         type: string
-      - description: максимальная сумма
+      - description: максимальная сумма диапазона
         in: query
         name: max_amount
         type: string


### PR DESCRIPTION
## Summary
- fix filtering by min and max amount for offers and update swagger docs
- cover amount range filtering with dedicated test

## Testing
- `./handlers.test -test.run TestListOffersAmountRange -test.v`


------
https://chatgpt.com/codex/tasks/task_e_68a5da57f034833297d8af5eed5a3f61