### PR TITLE
feat: websocket orders channel

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -117,6 +117,7 @@ func main() {
 
 	ws := r.Group("/ws")
 	ws.Use(handlers.AuthMiddleware(gormDB))
+	ws.GET("/orders", handlers.OrdersWS())
 	ws.GET("/orders/:id/chat", handlers.OrderChatWS(gormDB, chatCache))
 
 	if cfg.WatchersDebug {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1886,6 +1886,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/ws/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Подписка на события по ордерам клиента",
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Websocket ордеров клиента",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ws/orders/{id}/chat": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1879,6 +1879,34 @@
                 }
             }
         },
+        "/ws/orders": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Подписка на события по ордерам клиента",
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Websocket ордеров клиента",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ws/orders/{id}/chat": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1951,6 +1951,23 @@ paths:
       summary: Список платёжных методов
       tags:
       - reference
+  /ws/orders:
+    get:
+      description: Подписка на события по ордерам клиента
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Websocket ордеров клиента
+      tags:
+      - orders
   /ws/orders/{id}/chat:
     get:
       description: При подключении отправляет историю сообщений из кеша Redis

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -83,6 +83,36 @@ func CreateOrder(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
+
+		var full models.Order
+		if err := db.Preload("Offer").
+			Preload("Buyer").
+			Preload("Seller").
+			Preload("Author").
+			Preload("OfferOwner").
+			Preload("FromAsset").
+			Preload("ToAsset").
+			Preload("ClientPaymentMethod").
+			Preload("ClientPaymentMethod.Country").
+			Preload("ClientPaymentMethod.PaymentMethod").
+			Where("id = ?", order.ID).First(&full).Error; err == nil {
+			var cpm *models.ClientPaymentMethod
+			if full.ClientPaymentMethodID != "" {
+				cpm = &full.ClientPaymentMethod
+			}
+			of := models.OrderFull{
+				Order:               full,
+				Offer:               full.Offer,
+				Buyer:               full.Buyer,
+				Seller:              full.Seller,
+				Author:              full.Author,
+				OfferOwner:          full.OfferOwner,
+				FromAsset:           full.FromAsset,
+				ToAsset:             full.ToAsset,
+				ClientPaymentMethod: cpm,
+			}
+			broadcastOrderEvent(order.OfferOwnerID, newOrderEvent(of))
+		}
 		c.JSON(http.StatusOK, order)
 	}
 }

--- a/internal/handlers/order_ws.go
+++ b/internal/handlers/order_ws.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+
+	"ptop/internal/models"
+)
+
+var orderClients = struct {
+	sync.RWMutex
+	m map[string]map[*websocket.Conn]bool
+}{m: make(map[string]map[*websocket.Conn]bool)}
+
+type orderEvent struct {
+	Type  string           `json:"type"`
+	Order models.OrderFull `json:"order"`
+}
+
+func newOrderEvent(of models.OrderFull) orderEvent {
+	return orderEvent{Type: "order.created", Order: of}
+}
+
+func broadcastOrderEvent(clientID string, evt orderEvent) {
+	orderClients.Lock()
+	defer orderClients.Unlock()
+	for c := range orderClients.m[clientID] {
+		if err := c.WriteJSON(evt); err != nil {
+			c.Close()
+			delete(orderClients.m[clientID], c)
+		}
+	}
+}
+
+// OrdersWS godoc
+// @Summary Websocket ордеров клиента
+// @Description Подписка на события по ордерам клиента
+// @Tags orders
+// @Security BearerAuth
+// @Success 101 {string} string "Switching Protocols"
+// @Failure 401 {object} ErrorResponse
+// @Router /ws/orders [get]
+func OrdersWS() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		orderClients.Lock()
+		conns, ok := orderClients.m[clientID]
+		if !ok {
+			conns = make(map[*websocket.Conn]bool)
+			orderClients.m[clientID] = conns
+		}
+		conns[conn] = true
+		orderClients.Unlock()
+		defer func() {
+			orderClients.Lock()
+			delete(orderClients.m[clientID], conn)
+			orderClients.Unlock()
+		}()
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				break
+			}
+		}
+	}
+}

--- a/internal/handlers/order_ws_test.go
+++ b/internal/handlers/order_ws_test.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/shopspring/decimal"
+
+	"ptop/internal/models"
+)
+
+func TestOrdersWSOrderCreated(t *testing.T) {
+	db, r, _ := setupTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	body := `{"username":"seller","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"seller","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("seller login status %d", w.Code)
+	}
+	var sellerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &sellerTok)
+	var seller models.Client
+	db.Where("username = ?", "seller").First(&seller)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer login status %d", w.Code)
+	}
+	var buyerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &buyerTok)
+	var buyer models.Client
+	db.Where("username = ?", "buyer").First(&buyer)
+
+	w = httptest.NewRecorder()
+	body = `{"password":"pass","pincode":"1234"}`
+	req, _ = http.NewRequest("POST", "/auth/pincode", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer pincode status %d", w.Code)
+	}
+
+	asset1 := models.Asset{Name: "USD_evt", Type: models.AssetTypeFiat, IsActive: true}
+	asset2 := models.Asset{Name: "BTC_evt", Type: models.AssetTypeCrypto, IsActive: true}
+	if err := db.Create(&asset1).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	if err := db.Create(&asset2).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	offer := models.Offer{
+		MaxAmount:              decimal.RequireFromString("100"),
+		MinAmount:              decimal.RequireFromString("1"),
+		Amount:                 decimal.RequireFromString("50"),
+		Price:                  decimal.RequireFromString("0.1"),
+		FromAssetID:            asset1.ID,
+		ToAssetID:              asset2.ID,
+		OrderExpirationTimeout: 10,
+		TTL:                    time.Now().Add(24 * time.Hour),
+		ClientID:               seller.ID,
+	}
+	if err := db.Create(&offer).Error; err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders"
+
+	header := http.Header{"Authorization": {"Bearer " + sellerTok.AccessToken}}
+	sellerConn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("seller dial: %v", err)
+	}
+	defer sellerConn.Close()
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"1234"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("order status %d", w.Code)
+	}
+	var ord models.Order
+	json.Unmarshal(w.Body.Bytes(), &ord)
+
+	var evt struct {
+		Type  string           `json:"type"`
+		Order models.OrderFull `json:"order"`
+	}
+	if err := sellerConn.ReadJSON(&evt); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if evt.Type != "order.created" || evt.Order.ID != ord.ID || evt.Order.OfferOwnerID != seller.ID {
+		t.Fatalf("unexpected event %#v", evt)
+	}
+	if evt.Order.Offer.ID != offer.ID {
+		t.Fatalf("unexpected offer %s", evt.Order.Offer.ID)
+	}
+}
+
+func TestOrdersWSUnauthorized(t *testing.T) {
+	_, r, _ := setupTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders"
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil || resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized, got %v %v", err, resp)
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -121,6 +121,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 
 	ws := r.Group("/ws")
 	ws.Use(AuthMiddleware(db))
+	ws.GET("/orders", OrdersWS())
 	ws.GET("/orders/:id/chat", OrderChatWS(db, cache))
 
 	return db, r, ttl


### PR DESCRIPTION
## Summary
- add /ws/orders handler to subscribe clients to their orders
- notify offer owner via websocket when new order created
- cover with tests and swagger docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6f6f3e88332b65de084e5f171e9