### PR TITLE
feat: websocket order status

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -118,6 +118,7 @@ func main() {
 	ws := r.Group("/ws")
 	ws.Use(handlers.AuthMiddleware(gormDB))
 	ws.GET("/orders/:id/chat", handlers.OrderChatWS(gormDB, chatCache))
+	ws.GET("/orders/:id/status", handlers.OrderStatusWS(gormDB))
 
 	if cfg.WatchersDebug {
 		btcW, err := btcwatcher.New(gormDB, cfg.BtcRPCHost, cfg.BtcRPCUser, cfg.BtcRPCPass, nil, true)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1928,6 +1928,49 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/ws/orders/{id}/status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Отправляет события изменения статуса ордера.",
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Websocket уведомлений о статусе ордера",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID ордера",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2825,8 +2868,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "fileType": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1921,6 +1921,49 @@
                     }
                 }
             }
+        },
+        "/ws/orders/{id}/status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Отправляет события изменения статуса ордера.",
+                "tags": [
+                    "orders"
+                ],
+                "summary": "Websocket уведомлений о статусе ордера",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID ордера",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2818,8 +2861,7 @@
                     "type": "string"
                 },
                 "fileSize": {
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "fileType": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -587,7 +587,6 @@ definitions:
       createdAt:
         type: string
       fileSize:
-        format: int64
         type: integer
       fileType:
         type: string
@@ -1976,6 +1975,33 @@ paths:
       security:
       - BearerAuth: []
       summary: Websocket чат ордера
+      tags:
+      - orders
+  /ws/orders/{id}/status:
+    get:
+      description: Отправляет события изменения статуса ордера.
+      parameters:
+      - description: ID ордера
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Websocket уведомлений о статусе ордера
       tags:
       - orders
 securityDefinitions:

--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -83,6 +83,20 @@ func CreateOrder(db *gorm.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
 			return
 		}
+		var full models.Order
+		if err := db.Preload("Offer").
+			Preload("Buyer").
+			Preload("Seller").
+			Preload("Author").
+			Preload("OfferOwner").
+			Preload("FromAsset").
+			Preload("ToAsset").
+			Preload("ClientPaymentMethod").
+			Preload("ClientPaymentMethod.Country").
+			Preload("ClientPaymentMethod.PaymentMethod").
+			Where("id = ?", order.ID).First(&full).Error; err == nil {
+			broadcastOrderStatus(full)
+		}
 		c.JSON(http.StatusOK, order)
 	}
 }

--- a/internal/handlers/order_status_ws.go
+++ b/internal/handlers/order_status_ws.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+type orderStatusEvent struct {
+	Type  string           `json:"type"`
+	Order models.OrderFull `json:"order"`
+}
+
+var orderStatusClients = struct {
+	sync.RWMutex
+	m map[string]map[*websocket.Conn]bool
+}{m: make(map[string]map[*websocket.Conn]bool)}
+
+func sendOrderStatusEvent(conn *websocket.Conn, ord models.OrderFull) error {
+	return conn.WriteJSON(orderStatusEvent{Type: "order.status_changed", Order: ord})
+}
+
+func broadcastOrderStatus(order models.Order) {
+	ofull := models.OrderFull{
+		Order:      order,
+		Offer:      order.Offer,
+		Buyer:      order.Buyer,
+		Seller:     order.Seller,
+		Author:     order.Author,
+		OfferOwner: order.OfferOwner,
+		FromAsset:  order.FromAsset,
+		ToAsset:    order.ToAsset,
+	}
+	if order.ClientPaymentMethodID != "" {
+		ofull.ClientPaymentMethod = &order.ClientPaymentMethod
+	}
+	orderStatusClients.Lock()
+	conns := orderStatusClients.m[order.ID]
+	for c := range conns {
+		if err := sendOrderStatusEvent(c, ofull); err != nil {
+			c.Close()
+			delete(conns, c)
+		}
+	}
+	orderStatusClients.Unlock()
+}
+
+// OrderStatusWS godoc
+// @Summary Websocket уведомлений о статусе ордера
+// @Description Отправляет события изменения статуса ордера.
+// @Tags orders
+// @Security BearerAuth
+// @Param id path string true "ID ордера"
+// @Success 101 {string} string "Switching Protocols"
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Router /ws/orders/{id}/status [get]
+func OrderStatusWS(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		orderID := c.Param("id")
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		var order models.Order
+		if err := db.Preload("Offer").
+			Preload("Buyer").
+			Preload("Seller").
+			Preload("Author").
+			Preload("OfferOwner").
+			Preload("FromAsset").
+			Preload("ToAsset").
+			Preload("ClientPaymentMethod").
+			Preload("ClientPaymentMethod.Country").
+			Preload("ClientPaymentMethod.PaymentMethod").
+			Where("id = ?", orderID).First(&order).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid order"})
+			return
+		}
+		if clientID != order.AuthorID && clientID != order.OfferOwnerID {
+			c.JSON(http.StatusForbidden, ErrorResponse{Error: "forbidden"})
+			return
+		}
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		orderStatusClients.Lock()
+		conns, ok := orderStatusClients.m[order.ID]
+		if !ok {
+			conns = make(map[*websocket.Conn]bool)
+			orderStatusClients.m[order.ID] = conns
+		}
+		conns[conn] = true
+		orderStatusClients.Unlock()
+		defer func() {
+			orderStatusClients.Lock()
+			delete(orderStatusClients.m[order.ID], conn)
+			orderStatusClients.Unlock()
+		}()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				break
+			}
+		}
+	}
+}

--- a/internal/handlers/order_status_ws_test.go
+++ b/internal/handlers/order_status_ws_test.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/shopspring/decimal"
+	"ptop/internal/models"
+)
+
+func TestOrderStatusWS(t *testing.T) {
+	db, r, _ := setupTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// register seller
+	body := `{"username":"seller","password":"pass","password_confirm":"pass"}`
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"seller","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("seller login status %d", w.Code)
+	}
+	var sellerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &sellerTok)
+	var seller models.Client
+	db.Where("username = ?", "seller").First(&seller)
+
+	// register buyer
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"buyer","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer login status %d", w.Code)
+	}
+	var buyerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &buyerTok)
+	var buyer models.Client
+	db.Where("username = ?", "buyer").First(&buyer)
+
+	// set pincode for buyer
+	w = httptest.NewRecorder()
+	body = `{"password":"pass","pincode":"1234"}`
+	req, _ = http.NewRequest("POST", "/auth/pincode", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("buyer pincode status %d", w.Code)
+	}
+
+	// register hacker
+	w = httptest.NewRecorder()
+	body = `{"username":"hacker","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	w = httptest.NewRecorder()
+	body = `{"username":"hacker","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hacker login status %d", w.Code)
+	}
+	var hackerTok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &hackerTok)
+
+	asset1 := models.Asset{Name: "USD_ws_status", Type: models.AssetTypeFiat, IsActive: true}
+	asset2 := models.Asset{Name: "BTC_ws_status", Type: models.AssetTypeCrypto, IsActive: true}
+	if err := db.Create(&asset1).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	if err := db.Create(&asset2).Error; err != nil {
+		t.Fatalf("asset: %v", err)
+	}
+	offer := models.Offer{
+		MaxAmount:              decimal.RequireFromString("100"),
+		MinAmount:              decimal.RequireFromString("1"),
+		Amount:                 decimal.RequireFromString("50"),
+		Price:                  decimal.RequireFromString("0.1"),
+		FromAssetID:            asset1.ID,
+		ToAssetID:              asset2.ID,
+		OrderExpirationTimeout: 10,
+		TTL:                    time.Now().Add(24 * time.Hour),
+		ClientID:               seller.ID,
+	}
+	if err := db.Create(&offer).Error; err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	body = `{"offer_id":"` + offer.ID + `","amount":"5","pin_code":"1234"}`
+	req, _ = http.NewRequest("POST", "/client/orders", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+buyerTok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("order status %d", w.Code)
+	}
+	var ord models.Order
+	json.Unmarshal(w.Body.Bytes(), &ord)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/status"
+
+	// hacker tries to connect
+	header := http.Header{"Authorization": {"Bearer " + hackerTok.AccessToken}}
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err == nil || resp == nil || resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected forbidden, got %v %v", err, resp)
+	}
+
+	header = http.Header{"Authorization": {"Bearer " + buyerTok.AccessToken}}
+	buyerConn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("buyer dial: %v", err)
+	}
+	defer buyerConn.Close()
+
+	header = http.Header{"Authorization": {"Bearer " + sellerTok.AccessToken}}
+	sellerConn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("seller dial: %v", err)
+	}
+	defer sellerConn.Close()
+
+	if err := db.Model(&ord).Update("status", models.OrderStatusPaid).Error; err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	var full models.Order
+	if err := db.Preload("Offer").
+		Preload("Buyer").
+		Preload("Seller").
+		Preload("Author").
+		Preload("OfferOwner").
+		Preload("FromAsset").
+		Preload("ToAsset").
+		Where("id = ?", ord.ID).First(&full).Error; err != nil {
+		t.Fatalf("preload: %v", err)
+	}
+	broadcastOrderStatus(full)
+
+	var evt orderStatusEvent
+	if err := buyerConn.ReadJSON(&evt); err != nil {
+		t.Fatalf("buyer read: %v", err)
+	}
+	if evt.Type != "order.status_changed" || evt.Order.Status != models.OrderStatusPaid {
+		t.Fatalf("unexpected buyer event %#v", evt)
+	}
+	if err := sellerConn.ReadJSON(&evt); err != nil {
+		t.Fatalf("seller read: %v", err)
+	}
+	if evt.Type != "order.status_changed" || evt.Order.Status != models.OrderStatusPaid {
+		t.Fatalf("unexpected seller event %#v", evt)
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -122,6 +122,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	ws := r.Group("/ws")
 	ws.Use(AuthMiddleware(db))
 	ws.GET("/orders/:id/chat", OrderChatWS(db, cache))
+	ws.GET("/orders/:id/status", OrderStatusWS(db))
 
 	return db, r, ttl
 }


### PR DESCRIPTION
## Summary
- add WebSocket endpoint for order status changes
- broadcast order status updates to author and offer owner
- cover order status notifications with tests and swagger

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6f7943c8332a13dfafd36691d18