### PR TITLE
docs: расширена документация websocket

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1887,6 +1887,42 @@ const docTemplate = `{
                 }
             }
         },
+        "/ws/offers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Подключение для получения событий CRUD по офферам.",
+                "tags": [
+                    "offers"
+                ],
+                "summary": "WebSocket обновления офферов",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "канал",
+                        "name": "channel",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.OfferEvent"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ws/orders": {
             "get": {
                 "security": [
@@ -1894,7 +1930,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Подписка на события по ордерам клиента",
+                "description": "После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.",
                 "tags": [
                     "orders"
                 ],
@@ -1903,7 +1939,7 @@ const docTemplate = `{
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/handlers.OrderEvent"
                         }
                     },
                     "401": {
@@ -1922,7 +1958,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "При подключении отправляет историю сообщений из кеша Redis",
+                "description": "Подключает покупателя и продавца к чату ордера.",
                 "tags": [
                     "orders"
                 ],
@@ -1940,7 +1976,7 @@ const docTemplate = `{
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "403": {
@@ -1965,7 +2001,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Отправляет события изменения статуса ордера.",
+                "description": "Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.",
                 "tags": [
                     "orders"
                 ],
@@ -1983,7 +2019,7 @@ const docTemplate = `{
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/handlers.OrderStatusEvent"
                         }
                     },
                     "403": {
@@ -2201,6 +2237,18 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.OfferEvent": {
+            "type": "object",
+            "properties": {
+                "offer": {
+                    "$ref": "#/definitions/models.OfferFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "created"
+                }
+            }
+        },
         "handlers.OfferRequest": {
             "type": "object",
             "properties": {
@@ -2239,6 +2287,18 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.OrderEvent": {
+            "type": "object",
+            "properties": {
+                "order": {
+                    "$ref": "#/definitions/models.OrderFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "order.created"
+                }
+            }
+        },
         "handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
@@ -2261,6 +2321,18 @@ const docTemplate = `{
                 },
                 "pin_code": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.OrderStatusEvent": {
+            "type": "object",
+            "properties": {
+                "order": {
+                    "$ref": "#/definitions/models.OrderFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "order.status_changed"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1880,6 +1880,42 @@
                 }
             }
         },
+        "/ws/offers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Подключение для получения событий CRUD по офферам.",
+                "tags": [
+                    "offers"
+                ],
+                "summary": "WebSocket обновления офферов",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "канал",
+                        "name": "channel",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.OfferEvent"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ws/orders": {
             "get": {
                 "security": [
@@ -1887,7 +1923,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Подписка на события по ордерам клиента",
+                "description": "После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.",
                 "tags": [
                     "orders"
                 ],
@@ -1896,7 +1932,7 @@
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/handlers.OrderEvent"
                         }
                     },
                     "401": {
@@ -1915,7 +1951,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "При подключении отправляет историю сообщений из кеша Redis",
+                "description": "Подключает покупателя и продавца к чату ордера.",
                 "tags": [
                     "orders"
                 ],
@@ -1933,7 +1969,7 @@
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.OrderMessage"
                         }
                     },
                     "403": {
@@ -1958,7 +1994,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Отправляет события изменения статуса ордера.",
+                "description": "Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.",
                 "tags": [
                     "orders"
                 ],
@@ -1976,7 +2012,7 @@
                     "101": {
                         "description": "Switching Protocols",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/handlers.OrderStatusEvent"
                         }
                     },
                     "403": {
@@ -2194,6 +2230,18 @@
                 }
             }
         },
+        "handlers.OfferEvent": {
+            "type": "object",
+            "properties": {
+                "offer": {
+                    "$ref": "#/definitions/models.OfferFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "created"
+                }
+            }
+        },
         "handlers.OfferRequest": {
             "type": "object",
             "properties": {
@@ -2232,6 +2280,18 @@
                 }
             }
         },
+        "handlers.OrderEvent": {
+            "type": "object",
+            "properties": {
+                "order": {
+                    "$ref": "#/definitions/models.OrderFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "order.created"
+                }
+            }
+        },
         "handlers.OrderMessageRequest": {
             "type": "object",
             "properties": {
@@ -2254,6 +2314,18 @@
                 },
                 "pin_code": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.OrderStatusEvent": {
+            "type": "object",
+            "properties": {
+                "order": {
+                    "$ref": "#/definitions/models.OrderFull"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "order.status_changed"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -128,6 +128,14 @@ definitions:
       word:
         type: string
     type: object
+  handlers.OfferEvent:
+    properties:
+      offer:
+        $ref: '#/definitions/models.OfferFull'
+      type:
+        example: created
+        type: string
+    type: object
   handlers.OfferRequest:
     properties:
       amount:
@@ -153,6 +161,14 @@ definitions:
       type:
         type: string
     type: object
+  handlers.OrderEvent:
+    properties:
+      order:
+        $ref: '#/definitions/models.OrderFull'
+      type:
+        example: order.created
+        type: string
+    type: object
   handlers.OrderMessageRequest:
     properties:
       content:
@@ -167,6 +183,14 @@ definitions:
       offer_id:
         type: string
       pin_code:
+        type: string
+    type: object
+  handlers.OrderStatusEvent:
+    properties:
+      order:
+        $ref: '#/definitions/models.OrderFull'
+      type:
+        example: order.status_changed
         type: string
     type: object
   handlers.ProfileResponse:
@@ -1954,14 +1978,37 @@ paths:
       summary: Список платёжных методов
       tags:
       - reference
-  /ws/orders:
+  /ws/offers:
     get:
-      description: Подписка на события по ордерам клиента
+      description: Подключение для получения событий CRUD по офферам.
+      parameters:
+      - description: канал
+        in: query
+        name: channel
+        type: string
       responses:
         "101":
           description: Switching Protocols
           schema:
-            type: string
+            $ref: '#/definitions/handlers.OfferEvent'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: WebSocket обновления офферов
+      tags:
+      - offers
+  /ws/orders:
+    get:
+      description: После подключения авторизованный клиент получает события OrderEvent
+        о создании своих ордеров.
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            $ref: '#/definitions/handlers.OrderEvent'
         "401":
           description: Unauthorized
           schema:
@@ -1973,7 +2020,7 @@ paths:
       - orders
   /ws/orders/{id}/chat:
     get:
-      description: При подключении отправляет историю сообщений из кеша Redis
+      description: Подключает покупателя и продавца к чату ордера.
       parameters:
       - description: ID ордера
         in: path
@@ -1984,7 +2031,7 @@ paths:
         "101":
           description: Switching Protocols
           schema:
-            type: string
+            $ref: '#/definitions/models.OrderMessage'
         "403":
           description: Forbidden
           schema:
@@ -2000,7 +2047,8 @@ paths:
       - orders
   /ws/orders/{id}/status:
     get:
-      description: Отправляет события изменения статуса ордера.
+      description: Позволяет автору и владельцу оффера получать события OrderStatusEvent
+        при каждом изменении статуса указанного ордера.
       parameters:
       - description: ID ордера
         in: path
@@ -2011,7 +2059,7 @@ paths:
         "101":
           description: Switching Protocols
           schema:
-            type: string
+            $ref: '#/definitions/handlers.OrderStatusEvent'
         "403":
           description: Forbidden
           schema:

--- a/internal/handlers/order_chat_ws.go
+++ b/internal/handlers/order_chat_ws.go
@@ -14,11 +14,13 @@ import (
 
 // OrderChatWS godoc
 // @Summary Websocket чат ордера
-// @Description При подключении отправляет историю сообщений из кеша Redis
+// @Description Подключает покупателя и продавца к чату ордера.
+// После подключения сервер отправляет историю сообщений (models.OrderMessage).
+// Клиент отправляет новые сообщения в формате OrderMessageRequest, а получает сообщения типа models.OrderMessage.
 // @Tags orders
 // @Security BearerAuth
 // @Param id path string true "ID ордера"
-// @Success 101 {string} string "Switching Protocols"
+// @Success 101 {object} models.OrderMessage "Switching Protocols"
 // @Failure 403 {object} ErrorResponse
 // @Failure 404 {object} ErrorResponse
 // @Router /ws/orders/{id}/chat [get]

--- a/internal/handlers/order_status_ws.go
+++ b/internal/handlers/order_status_ws.go
@@ -11,8 +11,10 @@ import (
 	"ptop/internal/models"
 )
 
-type orderStatusEvent struct {
-	Type  string           `json:"type"`
+// OrderStatusEvent уведомление об изменении статуса ордера.
+// Type всегда `order.status_changed`.
+type OrderStatusEvent struct {
+	Type  string           `json:"type" example:"order.status_changed"`
 	Order models.OrderFull `json:"order"`
 }
 
@@ -22,7 +24,7 @@ var orderStatusClients = struct {
 }{m: make(map[string]map[*websocket.Conn]bool)}
 
 func sendOrderStatusEvent(conn *websocket.Conn, ord models.OrderFull) error {
-	return conn.WriteJSON(orderStatusEvent{Type: "order.status_changed", Order: ord})
+	return conn.WriteJSON(OrderStatusEvent{Type: "order.status_changed", Order: ord})
 }
 
 func broadcastOrderStatus(order models.Order) {
@@ -52,11 +54,11 @@ func broadcastOrderStatus(order models.Order) {
 
 // OrderStatusWS godoc
 // @Summary Websocket уведомлений о статусе ордера
-// @Description Отправляет события изменения статуса ордера.
+// @Description Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.
 // @Tags orders
 // @Security BearerAuth
 // @Param id path string true "ID ордера"
-// @Success 101 {string} string "Switching Protocols"
+// @Success 101 {object} handlers.OrderStatusEvent "Switching Protocols"
 // @Failure 403 {object} ErrorResponse
 // @Failure 404 {object} ErrorResponse
 // @Router /ws/orders/{id}/status [get]

--- a/internal/handlers/order_ws.go
+++ b/internal/handlers/order_ws.go
@@ -15,16 +15,18 @@ var orderClients = struct {
 	m map[string]map[*websocket.Conn]bool
 }{m: make(map[string]map[*websocket.Conn]bool)}
 
-type orderEvent struct {
-	Type  string           `json:"type"`
+// OrderEvent событие, отправляемое клиенту при создании его ордера.
+// Type всегда имеет значение `order.created`.
+type OrderEvent struct {
+	Type  string           `json:"type" example:"order.created"`
 	Order models.OrderFull `json:"order"`
 }
 
-func newOrderEvent(of models.OrderFull) orderEvent {
-	return orderEvent{Type: "order.created", Order: of}
+func newOrderEvent(of models.OrderFull) OrderEvent {
+	return OrderEvent{Type: "order.created", Order: of}
 }
 
-func broadcastOrderEvent(clientID string, evt orderEvent) {
+func broadcastOrderEvent(clientID string, evt OrderEvent) {
 	orderClients.Lock()
 	defer orderClients.Unlock()
 	for c := range orderClients.m[clientID] {
@@ -37,10 +39,11 @@ func broadcastOrderEvent(clientID string, evt orderEvent) {
 
 // OrdersWS godoc
 // @Summary Websocket ордеров клиента
-// @Description Подписка на события по ордерам клиента
+// @Description После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.
+// Клиенту не нужно отправлять данные, соединение используется только для чтения.
 // @Tags orders
 // @Security BearerAuth
-// @Success 101 {string} string "Switching Protocols"
+// @Success 101 {object} handlers.OrderEvent "Switching Protocols"
 // @Failure 401 {object} ErrorResponse
 // @Router /ws/orders [get]
 func OrdersWS() gin.HandlerFunc {


### PR DESCRIPTION
## Summary
- описаны структуры OfferEvent, OrderEvent и OrderStatusEvent
- расширено описание WS-эндпоинтов offers, orders, order chat и статусов

## Testing
- `go test ./internal/handlers` *(зависло, прервано)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e2b8b740833293841302c36f195b