### PR TITLE
Исправлен тип события в тесте статуса ордера

### DIFF
--- a/internal/handlers/order_status_ws_test.go
+++ b/internal/handlers/order_status_ws_test.go
@@ -171,7 +171,8 @@ func TestOrderStatusWS(t *testing.T) {
 	}
 	broadcastOrderStatus(full)
 
-	var evt orderStatusEvent
+	// используем экспортируемый тип события об изменении статуса
+	var evt OrderStatusEvent
 	if err := buyerConn.ReadJSON(&evt); err != nil {
 		t.Fatalf("buyer read: %v", err)
 	}


### PR DESCRIPTION
## Summary
- исправлен тип `OrderStatusEvent` в тестах вебсокета статуса ордера

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5f9d8d06c833282966ea50f036e26