### PR TITLE
feat: add notifications model and migration

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"ptop/config"
+	"ptop/internal/db"
+	"ptop/internal/models"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("config load failed: %v", err)
+	}
+
+	gormDB, err := db.NewDB(cfg.DSN)
+	if err != nil {
+		log.Fatalf("db connect failed: %v", err)
+	}
+
+	if err := gormDB.AutoMigrate(&models.Notification{}); err != nil {
+		log.Fatalf("auto migrate failed: %v", err)
+	}
+
+	migrator := gormDB.Migrator()
+	if err := migrator.CreateIndex(&models.Notification{}, "ClientID"); err != nil {
+		log.Fatalf("create index failed: %v", err)
+	}
+	if err := migrator.CreateIndex(&models.Notification{}, "SentAt"); err != nil {
+		log.Fatalf("create index failed: %v", err)
+	}
+	if err := migrator.CreateIndex(&models.Notification{}, "ReadAt"); err != nil {
+		log.Fatalf("create index failed: %v", err)
+	}
+
+	log.Println("migration completed")
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,6 +27,7 @@ func NewDB(dsn string) (*gorm.DB, error) {
 		&models.TransactionInternal{},
 		&models.Balance{},
 		&models.Escrow{},
+		&models.Notification{},
 	// &models.Product{}, и т.д.
 	); err != nil {
 		return nil, fmt.Errorf("auto migrate failed: %w", err)

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+	"ptop/internal/utils"
+)
+
+// Notification представляет уведомление
+// swagger:model
+type Notification struct {
+	ID        string          `gorm:"primaryKey;size:21" json:"id"`
+	ClientID  string          `gorm:"size:21;not null;index" json:"clientID"`
+	Type      string          `gorm:"type:varchar(255);not null" json:"type"`
+	Payload   json.RawMessage `gorm:"type:jsonb" json:"payload"`
+	SentAt    *time.Time      `gorm:"index" json:"sentAt"`
+	ReadAt    *time.Time      `gorm:"index" json:"readAt"`
+	CreatedAt time.Time       `gorm:"autoCreateTime" json:"createdAt"`
+	UpdatedAt time.Time       `gorm:"autoUpdateTime" json:"updatedAt"`
+}
+
+func (n *Notification) BeforeCreate(tx *gorm.DB) (err error) {
+	if n.ID == "" {
+		n.ID, err = utils.GenerateNanoID()
+	}
+	return
+}


### PR DESCRIPTION
## Summary
- add notification model with nanoid and timestamps
- create migration command for notifications with indexes
- include notification in auto-migrate

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adac7e696c8332ba64533544f17f28