### PR TITLE
feat: add notifications websocket hub

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,0 +1,70 @@
+package notifications
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+var (
+	db      *gorm.DB
+	clients = struct {
+		sync.RWMutex
+		m map[string]map[*websocket.Conn]bool
+	}{m: make(map[string]map[*websocket.Conn]bool)}
+)
+
+// SetDB устанавливает соединение с базой данных для обновления уведомлений.
+func SetDB(d *gorm.DB) {
+	db = d
+}
+
+// AddClient добавляет соединение вебсокета для клиента.
+func AddClient(clientID string, conn *websocket.Conn) {
+	clients.Lock()
+	defer clients.Unlock()
+	conns, ok := clients.m[clientID]
+	if !ok {
+		conns = make(map[*websocket.Conn]bool)
+		clients.m[clientID] = conns
+	}
+	conns[conn] = true
+}
+
+// RemoveClient удаляет соединение вебсокета для клиента.
+func RemoveClient(clientID string, conn *websocket.Conn) {
+	clients.Lock()
+	defer clients.Unlock()
+	if conns, ok := clients.m[clientID]; ok {
+		delete(conns, conn)
+	}
+}
+
+// Send отправляет уведомление через указанное соединение.
+// При успешной отправке поле SentAt обновляется в базе данных.
+func Send(conn *websocket.Conn, n models.Notification) error {
+	if err := conn.WriteJSON(n); err != nil {
+		return err
+	}
+	if db != nil {
+		now := time.Now()
+		db.Model(&models.Notification{}).Where("id = ?", n.ID).Update("sent_at", now)
+	}
+	return nil
+}
+
+// Broadcast отправляет уведомление всем соединениям клиента.
+func Broadcast(clientID string, n models.Notification) {
+	clients.Lock()
+	defer clients.Unlock()
+	for c := range clients.m[clientID] {
+		if err := Send(c, n); err != nil {
+			c.Close()
+			delete(clients.m[clientID], c)
+		}
+	}
+}

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -1,0 +1,144 @@
+package notifications
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+func setupDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Notification{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	SetDB(db)
+	return db
+}
+
+func dialWS(t *testing.T, ch chan<- models.Notification) *websocket.Conn {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var n models.Notification
+		if err := conn.ReadJSON(&n); err == nil {
+			ch <- n
+		}
+	}))
+	t.Cleanup(server.Close)
+	u := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return conn
+}
+
+func TestSend(t *testing.T) {
+	db := setupDB(t)
+	n := models.Notification{ClientID: "c1", Type: "test"}
+	if err := db.Create(&n).Error; err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ch := make(chan models.Notification, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		var recv models.Notification
+		if err := conn.ReadJSON(&recv); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		ch <- recv
+	}))
+	defer server.Close()
+
+	u := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := Send(conn, n); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	select {
+	case recv := <-ch:
+		if recv.ID != n.ID {
+			t.Fatalf("expected %s, got %s", n.ID, recv.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	var updated models.Notification
+	if err := db.First(&updated, "id = ?", n.ID).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if updated.SentAt == nil {
+		t.Fatalf("SentAt not updated")
+	}
+}
+
+func TestBroadcast(t *testing.T) {
+	db := setupDB(t)
+	clientID := "c1"
+	n := models.Notification{ClientID: clientID, Type: "test"}
+	if err := db.Create(&n).Error; err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ch1 := make(chan models.Notification, 1)
+	conn1 := dialWS(t, ch1)
+	defer conn1.Close()
+	AddClient(clientID, conn1)
+	defer RemoveClient(clientID, conn1)
+
+	ch2 := make(chan models.Notification, 1)
+	conn2 := dialWS(t, ch2)
+	defer conn2.Close()
+	AddClient(clientID, conn2)
+	defer RemoveClient(clientID, conn2)
+
+	Broadcast(clientID, n)
+
+	for i, ch := range []chan models.Notification{ch1, ch2} {
+		select {
+		case recv := <-ch:
+			if recv.ID != n.ID {
+				t.Fatalf("conn %d: expected %s, got %s", i+1, n.ID, recv.ID)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("conn %d: timeout", i+1)
+		}
+	}
+
+	var updated models.Notification
+	if err := db.First(&updated, "id = ?", n.ID).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if updated.SentAt == nil {
+		t.Fatalf("SentAt not updated")
+	}
+}


### PR DESCRIPTION
## Summary
- add notifications package with websocket hub and SentAt updates
- cover Send and Broadcast with unit tests

## Testing
- `go test ./internal/notifications -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adae1062408332b2834432e3253866