### PR TITLE
add notifications websocket handler

### DIFF
--- a/internal/handlers/notifications_ws.go
+++ b/internal/handlers/notifications_ws.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+	"ptop/internal/notifications"
+)
+
+// NotificationsWS godoc
+// @Summary Websocket уведомлений
+// @Description Подключает клиента к потоку уведомлений. После подключения сервер отправляет непрочитанные уведомления.
+// @Tags notifications
+// @Security BearerAuth
+// @Success 101 {object} models.Notification "Switching Protocols"
+// @Failure 401 {object} ErrorResponse
+// @Router /ws/notifications [get]
+func NotificationsWS(db *gorm.DB) gin.HandlerFunc {
+	notifications.SetDB(db)
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			return
+		}
+		notifications.AddClient(clientID, conn)
+		defer func() {
+			notifications.RemoveClient(clientID, conn)
+			conn.Close()
+		}()
+
+		var list []models.Notification
+		if err := db.Where("client_id = ? AND read_at IS NULL AND sent_at IS NULL", clientID).Find(&list).Error; err == nil {
+			for _, n := range list {
+				if err := notifications.Send(conn, n); err != nil {
+					return
+				}
+			}
+		}
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				break
+			}
+		}
+	}
+}

--- a/internal/handlers/notifications_ws_test.go
+++ b/internal/handlers/notifications_ws_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"ptop/internal/models"
+	"ptop/internal/notifications"
+)
+
+func TestNotificationsWS(t *testing.T) {
+	db, r, _ := setupTest(t)
+	notifications.SetDB(db)
+	r.GET("/ws/notifications", AuthMiddleware(db), NotificationsWS(db))
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	w := httptest.NewRecorder()
+	body := `{"username":"user","password":"pass","password_confirm":"pass"}`
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"user","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status %d", w.Code)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok)
+
+	var client models.Client
+	if err := db.Where("username = ?", "user").First(&client).Error; err != nil {
+		t.Fatalf("query client: %v", err)
+	}
+
+	n1 := models.Notification{ClientID: client.ID, Type: "test1"}
+	if err := db.Create(&n1).Error; err != nil {
+		t.Fatalf("create n1: %v", err)
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/notifications"
+	header := http.Header{"Authorization": {"Bearer " + tok.AccessToken}}
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("handshake status %d", resp.StatusCode)
+	}
+	defer conn.Close()
+
+	var recv models.Notification
+	if err := conn.ReadJSON(&recv); err != nil {
+		t.Fatalf("read initial: %v", err)
+	}
+	if recv.ID != n1.ID {
+		t.Fatalf("unexpected initial %s", recv.ID)
+	}
+
+	n2 := models.Notification{ClientID: client.ID, Type: "test2"}
+	if err := db.Create(&n2).Error; err != nil {
+		t.Fatalf("create n2: %v", err)
+	}
+	notifications.Broadcast(client.ID, n2)
+
+	if err := conn.ReadJSON(&recv); err != nil {
+		t.Fatalf("read broadcast: %v", err)
+	}
+	if recv.ID != n2.ID {
+		t.Fatalf("unexpected broadcast %s", recv.ID)
+	}
+}


### PR DESCRIPTION
## Summary
- add websocket endpoint for user notifications with backlog sending
- cover notifications websocket with tests

## Testing
- `go test ./...` *(failed: process did not complete within the expected time)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1cc83cc83329065eba7ec8d8db1