### PR TITLE
feat: mark notifications as read

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	api.POST("/client/order", handlers.CreateOrder(gormDB))
 	api.GET("/client/orders", handlers.ListClientOrders(gormDB))
+	api.PATCH("/notifications/:id/read", handlers.ReadNotification(gormDB))
 
 	ws := r.Group("/ws")
 	ws.Use(handlers.AuthMiddleware(gormDB))
@@ -121,7 +122,6 @@ func main() {
 	ws.GET("/orders/:id/chat", handlers.OrderChatWS(gormDB, chatCache))
 	ws.GET("/orders/:id/status", handlers.OrderStatusWS(gormDB))
 	ws.GET("/offers", gin.WrapF(handlers.OffersWS()))
-
 
 	if cfg.WatchersDebug {
 		btcW, err := btcwatcher.New(gormDB, cfg.BtcRPCHost, cfg.BtcRPCUser, cfg.BtcRPCPass, nil, true)

--- a/internal/handlers/notifications_read.go
+++ b/internal/handlers/notifications_read.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// ReadNotification godoc
+// @Summary Отметить уведомление прочитанным
+// @Tags notifications
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "ID уведомления"
+// @Success 200 {object} models.Notification
+// @Failure 404 {object} ErrorResponse
+// @Router /notifications/{id}/read [patch]
+func ReadNotification(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		id := c.Param("id")
+		var n models.Notification
+		if err := db.Where("id = ? AND client_id = ?", id, clientID).First(&n).Error; err != nil {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "invalid notification"})
+			return
+		}
+		now := time.Now()
+		if err := db.Model(&n).Update("read_at", now).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		n.ReadAt = &now
+		c.JSON(http.StatusOK, n)
+	}
+}

--- a/internal/handlers/notifications_read_test.go
+++ b/internal/handlers/notifications_read_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"ptop/internal/models"
+)
+
+func TestReadNotification(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	// register first user
+	w := httptest.NewRecorder()
+	body := `{"username":"user1","password":"pass","password_confirm":"pass"}`
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"user1","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user1 login status %d", w.Code)
+	}
+	var tok1 struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok1)
+
+	// register second user
+	w = httptest.NewRecorder()
+	body = `{"username":"user2","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"user2","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user2 login status %d", w.Code)
+	}
+	var tok2 struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok2)
+
+	var client1 models.Client
+	db.Where("username = ?", "user1").First(&client1)
+
+	// create notification for user1
+	n := models.Notification{ClientID: client1.ID, Type: "test"}
+	if err := db.Create(&n).Error; err != nil {
+		t.Fatalf("create notification: %v", err)
+	}
+
+	// user1 marks notification read
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PATCH", "/notifications/"+n.ID+"/read", nil)
+	req.Header.Set("Authorization", "Bearer "+tok1.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("read status %d", w.Code)
+	}
+	var upd models.Notification
+	json.Unmarshal(w.Body.Bytes(), &upd)
+	if upd.ReadAt == nil {
+		t.Fatalf("expected readAt not nil")
+	}
+
+	// user2 tries to mark someone else's notification
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PATCH", "/notifications/"+n.ID+"/read", nil)
+	req.Header.Set("Authorization", "Bearer "+tok2.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -110,6 +110,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	api.GET("/orders/:id/messages", ListOrderMessages(db))
 	api.POST("/orders/:id/messages", CreateOrderMessage(db, store, cache))
 	api.PATCH("/orders/:id/messages/:msgId/read", ReadOrderMessage(db))
+	api.PATCH("/notifications/:id/read", ReadNotification(db))
 
 	maxOffers := 1
 	api.GET("/offers", ListOffers(db))


### PR DESCRIPTION
## Summary
- add handler to mark notifications as read
- document and test read notifications endpoint

## Testing
- `go test ./internal/handlers -run TestReadNotification -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68adb6af86648332828a50f914e13d3e