### PR TITLE
feat: add notifications list handler

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	api.POST("/client/order", handlers.CreateOrder(gormDB))
 	api.GET("/client/orders", handlers.ListClientOrders(gormDB))
+	api.GET("/notifications", handlers.ListNotifications(gormDB))
 	api.PATCH("/notifications/:id/read", handlers.ReadNotification(gormDB))
 
 	ws := r.Group("/ws")

--- a/internal/handlers/notifications_list.go
+++ b/internal/handlers/notifications_list.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"ptop/internal/models"
+)
+
+// ListNotifications godoc
+// @Summary Список уведомлений клиента
+// @Tags notifications
+// @Security BearerAuth
+// @Produce json
+// @Param limit query int false "лимит"
+// @Param offset query int false "смещение"
+// @Success 200 {array} models.Notification
+// @Router /notifications [get]
+func ListNotifications(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIDVal, ok := c.Get("client_id")
+		if !ok {
+			c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "no client"})
+			return
+		}
+		clientID := clientIDVal.(string)
+		limit, offset := parsePagination(c)
+		var ns []models.Notification
+		if err := db.Where("client_id = ?", clientID).
+			Order("created_at desc").
+			Limit(limit).Offset(offset).Find(&ns).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, ns)
+	}
+}

--- a/internal/handlers/notifications_list_test.go
+++ b/internal/handlers/notifications_list_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"ptop/internal/models"
+)
+
+func TestListNotifications(t *testing.T) {
+	db, r, _ := setupTest(t)
+
+	// register first user
+	w := httptest.NewRecorder()
+	body := `{"username":"user1","password":"pass","password_confirm":"pass"}`
+	req, _ := http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"user1","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user1 login status %d", w.Code)
+	}
+	var tok1 struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok1)
+
+	// register second user
+	w = httptest.NewRecorder()
+	body = `{"username":"user2","password":"pass","password_confirm":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	w = httptest.NewRecorder()
+	body = `{"username":"user2","password":"pass"}`
+	req, _ = http.NewRequest("POST", "/auth/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user2 login status %d", w.Code)
+	}
+	var tok2 struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &tok2)
+
+	var client1, client2 models.Client
+	db.Where("username = ?", "user1").First(&client1)
+	db.Where("username = ?", "user2").First(&client2)
+
+	// create notifications for user1
+	var n1, n2, n3 models.Notification
+	n1 = models.Notification{ClientID: client1.ID, Type: "test"}
+	db.Create(&n1)
+	n2 = models.Notification{ClientID: client1.ID, Type: "test"}
+	db.Create(&n2)
+	n3 = models.Notification{ClientID: client1.ID, Type: "test"}
+	db.Create(&n3)
+	// create notification for user2
+	db.Create(&models.Notification{ClientID: client2.ID, Type: "test"})
+
+	// user1 list first page
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/notifications?limit=2", nil)
+	req.Header.Set("Authorization", "Bearer "+tok1.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status %d", w.Code)
+	}
+	var list []models.Notification
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 2 {
+		t.Fatalf("expected 2, got %d", len(list))
+	}
+	if list[0].ID != n3.ID || list[1].ID != n2.ID {
+		t.Fatalf("unexpected order")
+	}
+
+	// user1 list second page
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/notifications?limit=2&offset=2", nil)
+	req.Header.Set("Authorization", "Bearer "+tok1.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list2 status %d", w.Code)
+	}
+	list = nil
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 || list[0].ID != n1.ID {
+		t.Fatalf("expected n1")
+	}
+
+	// user2 list
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/notifications", nil)
+	req.Header.Set("Authorization", "Bearer "+tok2.AccessToken)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user2 list status %d", w.Code)
+	}
+	list = nil
+	json.Unmarshal(w.Body.Bytes(), &list)
+	if len(list) != 1 || list[0].ClientID != client2.ID {
+		t.Fatalf("expected only user2 notifications")
+	}
+}

--- a/internal/handlers/test_utils_test.go
+++ b/internal/handlers/test_utils_test.go
@@ -110,6 +110,7 @@ func setupTest(t *testing.T) (*gorm.DB, *gin.Engine, map[string]time.Duration) {
 	api.GET("/orders/:id/messages", ListOrderMessages(db))
 	api.POST("/orders/:id/messages", CreateOrderMessage(db, store, cache))
 	api.PATCH("/orders/:id/messages/:msgId/read", ReadOrderMessage(db))
+	api.GET("/notifications", ListNotifications(db))
 	api.PATCH("/notifications/:id/read", ReadNotification(db))
 
 	maxOffers := 1


### PR DESCRIPTION
## Summary
- add GET /notifications handler with pagination
- document and test notifications listing

## Testing
- `go test ./...`
- `swag init -g cmd/api/main.go` *(fails: models.Notification: [payload]: cannot find type definition: json.RawMessage)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8a51e888332ac1089b4044d8440