### PR TITLE
feat: support query token for websockets

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -390,11 +390,16 @@ func AuthMiddleware(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.GetHeader("Authorization")
 		parts := strings.SplitN(header, " ", 2)
-		if len(parts) != 2 || parts[0] != "Bearer" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization"})
-			return
+		tokenStr := ""
+		if len(parts) == 2 && parts[0] == "Bearer" {
+			tokenStr = parts[1]
+		} else {
+			tokenStr = c.Query("token")
+			if tokenStr == "" {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization"})
+				return
+			}
 		}
-		tokenStr := parts[1]
 		var token models.Token
 		if err := db.Where("token = ? AND type = ?", tokenStr, "access").First(&token).Error; err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})

--- a/internal/handlers/create_order_message_ws_test.go
+++ b/internal/handlers/create_order_message_ws_test.go
@@ -117,9 +117,8 @@ func TestCreateOrderMessageBroadcast(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &ord)
 
 	// seller connects via WebSocket
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/chat"
-	header := http.Header{"Authorization": {"Bearer " + sellerTok.AccessToken}}
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/chat?token=" + sellerTok.AccessToken
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("seller dial: %v", err)
 	}

--- a/internal/handlers/notifications_ws.go
+++ b/internal/handlers/notifications_ws.go
@@ -14,7 +14,7 @@ import (
 // @Summary Websocket уведомлений
 // @Description Подключает клиента к потоку уведомлений. После подключения сервер отправляет непрочитанные уведомления.
 // @Tags notifications
-// @Security BearerAuth
+// @Param token query string true "access token"
 // @Success 101 {object} models.Notification "Switching Protocols"
 // @Failure 401 {object} ErrorResponse
 // @Router /ws/notifications [get]

--- a/internal/handlers/notifications_ws_test.go
+++ b/internal/handlers/notifications_ws_test.go
@@ -50,9 +50,8 @@ func TestNotificationsWS(t *testing.T) {
 		t.Fatalf("create n1: %v", err)
 	}
 
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/notifications"
-	header := http.Header{"Authorization": {"Bearer " + tok.AccessToken}}
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/notifications?token=" + tok.AccessToken
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/internal/handlers/offers_ws.go
+++ b/internal/handlers/offers_ws.go
@@ -27,7 +27,7 @@ var offerWSConns = struct {
 // Клиенту необходимо установить соединение и при необходимости передать query `channel`.
 // В ответ сервер отправляет сообщения формата OfferEvent: {"type":"created","offer":OfferFull}.
 // @Tags offers
-// @Security BearerAuth
+// @Param token query string true "access token"
 // @Param channel query string false "канал"
 // @Success 101 {object} handlers.OfferEvent "Switching Protocols"
 // @Failure 403 {object} ErrorResponse

--- a/internal/handlers/offers_ws_test.go
+++ b/internal/handlers/offers_ws_test.go
@@ -54,9 +54,8 @@ func TestOffersWS(t *testing.T) {
 		t.Fatalf("asset2: %v", err)
 	}
 
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/offers"
-	header := http.Header{"Authorization": {"Bearer " + tok.AccessToken}}
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/offers?token=" + tok.AccessToken
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/internal/handlers/order_chat_ws.go
+++ b/internal/handlers/order_chat_ws.go
@@ -20,7 +20,7 @@ import (
 // После подключения сервер отправляет историю сообщений (models.OrderMessage).
 // Клиент отправляет новые сообщения в формате OrderMessageRequest, а получает сообщения типа models.OrderMessage.
 // @Tags orders
-// @Security BearerAuth
+// @Param token query string true "access token"
 // @Param id path string true "ID ордера"
 // @Success 101 {object} models.OrderMessage "Switching Protocols"
 // @Failure 403 {object} ErrorResponse

--- a/internal/handlers/order_status_ws.go
+++ b/internal/handlers/order_status_ws.go
@@ -74,7 +74,7 @@ func broadcastOrderStatus(order models.Order) {
 // @Summary Websocket уведомлений о статусе ордера
 // @Description Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.
 // @Tags orders
-// @Security BearerAuth
+// @Param token query string true "access token"
 // @Param id path string true "ID ордера"
 // @Success 101 {object} handlers.OrderStatusEvent "Switching Protocols"
 // @Failure 403 {object} ErrorResponse

--- a/internal/handlers/order_status_ws_test.go
+++ b/internal/handlers/order_status_ws_test.go
@@ -126,17 +126,16 @@ func TestOrderStatusWS(t *testing.T) {
 	var ord models.Order
 	json.Unmarshal(w.Body.Bytes(), &ord)
 
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/status"
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/status?token=" + hackerTok.AccessToken
 
 	// hacker tries to connect
-	header := http.Header{"Authorization": {"Bearer " + hackerTok.AccessToken}}
-	_, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err == nil || resp == nil || resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected forbidden, got %v %v", err, resp)
 	}
 
-	header = http.Header{"Authorization": {"Bearer " + buyerTok.AccessToken}}
-	buyerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	wsURL = "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/status?token=" + buyerTok.AccessToken
+	buyerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("buyer dial: %v", err)
 	}
@@ -145,8 +144,8 @@ func TestOrderStatusWS(t *testing.T) {
 	}
 	defer buyerConn.Close()
 
-	header = http.Header{"Authorization": {"Bearer " + sellerTok.AccessToken}}
-	sellerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	wsURL = "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders/" + ord.ID + "/status?token=" + sellerTok.AccessToken
+	sellerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("seller dial: %v", err)
 	}

--- a/internal/handlers/order_ws.go
+++ b/internal/handlers/order_ws.go
@@ -42,7 +42,7 @@ func broadcastOrderEvent(clientID string, evt OrderEvent) {
 // @Description После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.
 // Клиенту не нужно отправлять данные, соединение используется только для чтения.
 // @Tags orders
-// @Security BearerAuth
+// @Param token query string true "access token"
 // @Success 101 {object} handlers.OrderEvent "Switching Protocols"
 // @Failure 401 {object} ErrorResponse
 // @Router /ws/orders [get]

--- a/internal/handlers/order_ws_test.go
+++ b/internal/handlers/order_ws_test.go
@@ -93,10 +93,9 @@ func TestOrdersWSOrderCreated(t *testing.T) {
 		t.Fatalf("offer: %v", err)
 	}
 
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders"
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/orders?token=" + sellerTok.AccessToken
 
-	header := http.Header{"Authorization": {"Bearer " + sellerTok.AccessToken}}
-	sellerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	sellerConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("seller dial: %v", err)
 	}


### PR DESCRIPTION
## Summary
- allow passing access token via `token` query parameter in AuthMiddleware
- document websocket auth via query token
- adjust websocket tests to send token in URL

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adbbc87c04833288d9c411b66ac73f