### PR TITLE
docs: describe notifications channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ wss://<host>/ws/orders/{orderID}/chat
 ```
 
 Каждое отправленное сообщение будет сохранено в БД и рассылается всем подключённым участникам ордера.
+## Уведомления
+
+Для доставки событий (создание ордера, изменение статуса, входящие сообщения и т.п.) используется общий канал уведомлений.
+
+### Подключение по WebSocket
+
+```
+wss://<host>/ws/notifications
+```
+
+Перед подключением необходимо получить `access_token` и передать его в заголовке `Authorization: Bearer <token>` или в параметре `token`.
+
+После установления соединения сервер отправит все непрочитанные уведомления пользователя.
+
+### REST API
+
+- `GET /notifications` — список уведомлений с поддержкой пагинации.
+- `PATCH /notifications/{id}/read` — отметка уведомления как прочитанного.
+
 ## Примеры подключения к WebSocket из React
 
 ### Получение уведомлений о создании ордеров
@@ -107,6 +126,16 @@ useEffect(() => {
 ```tsx
 useEffect(() => {
   const ws = new WebSocket(`wss://api.example.com/ws/offers?token=${token}`);
+  ws.onmessage = (evt) => console.log(JSON.parse(evt.data));
+  return () => ws.close();
+}, [token]);
+```
+
+### Лента уведомлений
+
+```tsx
+useEffect(() => {
+  const ws = new WebSocket(`wss://api.example.com/ws/notifications?token=${token}`);
   ws.onmessage = (evt) => console.log(JSON.parse(evt.data));
   return () => ws.close();
 }, [token]);

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -119,6 +119,7 @@ func main() {
 
 	ws := r.Group("/ws")
 	ws.Use(handlers.AuthMiddleware(gormDB))
+	ws.GET("/notifications", handlers.NotificationsWS(gormDB))
 	ws.GET("/orders", handlers.OrdersWS())
 	ws.GET("/orders/:id/chat", handlers.OrderChatWS(gormDB, chatCache))
 	ws.GET("/orders/:id/status", handlers.OrderStatusWS(gormDB))

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1602,6 +1602,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/notifications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Список уведомлений клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Notification"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notifications/{id}/read": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Отметить уведомление прочитанным",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID уведомления",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/offers": {
             "get": {
                 "security": [
@@ -1887,19 +1967,53 @@ const docTemplate = `{
                 }
             }
         },
-        "/ws/offers": {
+        "/ws/notifications": {
             "get": {
-                "security": [
+                "description": "Подключает клиента к потоку уведомлений. После подключения сервер отправляет непрочитанные уведомления.",
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Websocket уведомлений",
+                "parameters": [
                     {
-                        "BearerAuth": []
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
                     }
                 ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ws/offers": {
+            "get": {
                 "description": "Подключение для получения событий CRUD по офферам.",
                 "tags": [
                     "offers"
                 ],
                 "summary": "WebSocket обновления офферов",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "канал",
@@ -1925,16 +2039,20 @@ const docTemplate = `{
         },
         "/ws/orders": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket ордеров клиента",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "101": {
                         "description": "Switching Protocols",
@@ -1953,17 +2071,19 @@ const docTemplate = `{
         },
         "/ws/orders/{id}/chat": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Подключает покупателя и продавца к чату ордера.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket чат ордера",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "ID ордера",
@@ -1996,17 +2116,19 @@ const docTemplate = `{
         },
         "/ws/orders/{id}/status": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket уведомлений о статусе ордера",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "ID ордера",
@@ -2689,6 +2811,35 @@ const docTemplate = `{
                 "MessageTypeSystem",
                 "MessageTypeFile"
             ]
+        },
+        "models.Notification": {
+            "type": "object",
+            "properties": {
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "object"
+                },
+                "readAt": {
+                    "type": "string"
+                },
+                "sentAt": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
         },
         "models.Offer": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1595,6 +1595,86 @@
                 }
             }
         },
+        "/notifications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Список уведомлений клиента",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "лимит",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "смещение",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Notification"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notifications/{id}/read": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Отметить уведомление прочитанным",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID уведомления",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/offers": {
             "get": {
                 "security": [
@@ -1880,19 +1960,53 @@
                 }
             }
         },
-        "/ws/offers": {
+        "/ws/notifications": {
             "get": {
-                "security": [
+                "description": "Подключает клиента к потоку уведомлений. После подключения сервер отправляет непрочитанные уведомления.",
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Websocket уведомлений",
+                "parameters": [
                     {
-                        "BearerAuth": []
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
                     }
                 ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "$ref": "#/definitions/models.Notification"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ws/offers": {
+            "get": {
                 "description": "Подключение для получения событий CRUD по офферам.",
                 "tags": [
                     "offers"
                 ],
                 "summary": "WebSocket обновления офферов",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "канал",
@@ -1918,16 +2032,20 @@
         },
         "/ws/orders": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "После подключения авторизованный клиент получает события OrderEvent о создании своих ордеров.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket ордеров клиента",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "101": {
                         "description": "Switching Protocols",
@@ -1946,17 +2064,19 @@
         },
         "/ws/orders/{id}/chat": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Подключает покупателя и продавца к чату ордера.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket чат ордера",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "ID ордера",
@@ -1989,17 +2109,19 @@
         },
         "/ws/orders/{id}/status": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
                 "description": "Позволяет автору и владельцу оффера получать события OrderStatusEvent при каждом изменении статуса указанного ордера.",
                 "tags": [
                     "orders"
                 ],
                 "summary": "Websocket уведомлений о статусе ордера",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "access token",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "ID ордера",
@@ -2682,6 +2804,35 @@
                 "MessageTypeSystem",
                 "MessageTypeFile"
             ]
+        },
+        "models.Notification": {
+            "type": "object",
+            "properties": {
+                "clientID": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "object"
+                },
+                "readAt": {
+                    "type": "string"
+                },
+                "sentAt": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
         },
         "models.Offer": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -426,6 +426,25 @@ definitions:
     - MessageTypeText
     - MessageTypeSystem
     - MessageTypeFile
+  models.Notification:
+    properties:
+      clientID:
+        type: string
+      createdAt:
+        type: string
+      id:
+        type: string
+      payload:
+        type: object
+      readAt:
+        type: string
+      sentAt:
+        type: string
+      type:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   models.Offer:
     properties:
       TTL:
@@ -1794,6 +1813,55 @@ paths:
       summary: Проверка состояния сервиса
       tags:
       - health
+  /notifications:
+    get:
+      parameters:
+      - description: лимит
+        in: query
+        name: limit
+        type: integer
+      - description: смещение
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.Notification'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: Список уведомлений клиента
+      tags:
+      - notifications
+  /notifications/{id}/read:
+    patch:
+      parameters:
+      - description: ID уведомления
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Notification'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Отметить уведомление прочитанным
+      tags:
+      - notifications
   /offers:
     get:
       parameters:
@@ -1978,10 +2046,37 @@ paths:
       summary: Список платёжных методов
       tags:
       - reference
+  /ws/notifications:
+    get:
+      description: Подключает клиента к потоку уведомлений. После подключения сервер
+        отправляет непрочитанные уведомления.
+      parameters:
+      - description: access token
+        in: query
+        name: token
+        required: true
+        type: string
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            $ref: '#/definitions/models.Notification'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      summary: Websocket уведомлений
+      tags:
+      - notifications
   /ws/offers:
     get:
       description: Подключение для получения событий CRUD по офферам.
       parameters:
+      - description: access token
+        in: query
+        name: token
+        required: true
+        type: string
       - description: канал
         in: query
         name: channel
@@ -1995,8 +2090,6 @@ paths:
           description: Forbidden
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: WebSocket обновления офферов
       tags:
       - offers
@@ -2004,6 +2097,12 @@ paths:
     get:
       description: После подключения авторизованный клиент получает события OrderEvent
         о создании своих ордеров.
+      parameters:
+      - description: access token
+        in: query
+        name: token
+        required: true
+        type: string
       responses:
         "101":
           description: Switching Protocols
@@ -2013,8 +2112,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: Websocket ордеров клиента
       tags:
       - orders
@@ -2022,6 +2119,11 @@ paths:
     get:
       description: Подключает покупателя и продавца к чату ордера.
       parameters:
+      - description: access token
+        in: query
+        name: token
+        required: true
+        type: string
       - description: ID ордера
         in: path
         name: id
@@ -2040,8 +2142,6 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: Websocket чат ордера
       tags:
       - orders
@@ -2050,6 +2150,11 @@ paths:
       description: Позволяет автору и владельцу оффера получать события OrderStatusEvent
         при каждом изменении статуса указанного ордера.
       parameters:
+      - description: access token
+        in: query
+        name: token
+        required: true
+        type: string
       - description: ID ордера
         in: path
         name: id
@@ -2068,8 +2173,6 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
-      security:
-      - BearerAuth: []
       summary: Websocket уведомлений о статусе ордера
       tags:
       - orders

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -14,7 +14,7 @@ type Notification struct {
 	ID        string          `gorm:"primaryKey;size:21" json:"id"`
 	ClientID  string          `gorm:"size:21;not null;index" json:"clientID"`
 	Type      string          `gorm:"type:varchar(255);not null" json:"type"`
-	Payload   json.RawMessage `gorm:"type:jsonb" json:"payload"`
+	Payload   json.RawMessage `gorm:"type:jsonb" json:"payload" swaggertype:"object"`
 	SentAt    *time.Time      `gorm:"index" json:"sentAt"`
 	ReadAt    *time.Time      `gorm:"index" json:"readAt"`
 	CreatedAt time.Time       `gorm:"autoCreateTime" json:"createdAt"`


### PR DESCRIPTION
## Summary
- document notifications websocket and REST endpoints in README and swagger
- expose `/ws/notifications` websocket endpoint in API router
- mark notification payload as object for swagger generation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adaa16bd208332883e3410d64673ca